### PR TITLE
Implement `basic.deliver`

### DIFF
--- a/internal/core/amqp/basic.go
+++ b/internal/core/amqp/basic.go
@@ -73,6 +73,46 @@ func createBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string
 	return frame
 }
 
+// createBasicDeliverFrame creates a Basic.Deliver (60) frame for the given message and delivery tag.
+// Sent fields:
+// - consumer-tag (shortstr)
+// - delivery-tag (longlong)
+// - redelivered (bit)
+// - exchange (shortstr)
+// - routing-key (shortstr)
+func createBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte {
+	consumerTagKv := KeyValue{
+		Key:   STRING_SHORT,
+		Value: consumerTag,
+	}
+	deliveryTagKv := KeyValue{
+		Key:   INT_LONG_LONG,
+		Value: deliveryTag,
+	}
+	redeliveredKv := KeyValue{
+		Key:   BIT,
+		Value: redelivered,
+	}
+	exchangeKv := KeyValue{
+		Key:   STRING_SHORT,
+		Value: exchange,
+	}
+	routingKeyKv := KeyValue{
+		Key:   STRING_SHORT,
+		Value: routingKey,
+	}
+	content := ContentList{
+		KeyValuePairs: []KeyValue{consumerTagKv, deliveryTagKv, redeliveredKv, exchangeKv, routingKeyKv},
+	}
+	frame := ResponseMethodMessage{
+		Channel:  channel,
+		ClassID:  uint16(BASIC),
+		MethodID: uint16(BASIC_DELIVER),
+		Content:  content,
+	}.FormatMethodFrame()
+	return frame
+}
+
 func createBasicGetEmptyFrame(request *RequestMethodMessage) []byte {
 	// Send Basic.GetEmpty
 	reserved1 := KeyValue{

--- a/internal/core/amqp/basic.go
+++ b/internal/core/amqp/basic.go
@@ -259,13 +259,13 @@ func parseBasicHeader(headerPayload []byte) (*HeaderFrame, error) {
 	if weight != 0 {
 		return nil, fmt.Errorf("weight must be 0")
 	}
-	log.Printf("[DEBUG] Weight: %d\n", weight)
+	log.Trace().Msgf("- HEADER - Weight: %d\n", weight)
 
 	bodySize, err := DecodeLongLongInt(buf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode body size: %v", err)
 	}
-	log.Printf("[DEBUG] Body Size: %d\n", bodySize)
+	log.Trace().Msgf("- HEADER - Body Size: %d\n", bodySize)
 
 	shortFlags, err := DecodeShortInt(buf)
 	if err != nil {
@@ -276,7 +276,7 @@ func parseBasicHeader(headerPayload []byte) (*HeaderFrame, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode properties: %v", err)
 	}
-	log.Printf("[DEBUG] properties: %v\n", properties)
+	log.Trace().Msgf("- HEADER - properties: %v\n", properties)
 	header := &HeaderFrame{
 		ClassID:    classID,
 		BodySize:   bodySize,

--- a/internal/core/amqp/basic.go
+++ b/internal/core/amqp/basic.go
@@ -74,12 +74,6 @@ func createBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string
 }
 
 // createBasicDeliverFrame creates a Basic.Deliver (60) frame for the given message and delivery tag.
-// Sent fields:
-// - consumer-tag (shortstr)
-// - delivery-tag (longlong)
-// - redelivered (bit)
-// - exchange (shortstr)
-// - routing-key (shortstr)
 func createBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte {
 	consumerTagKv := KeyValue{
 		Key:   STRING_SHORT,

--- a/internal/core/amqp/basic_test.go
+++ b/internal/core/amqp/basic_test.go
@@ -8,17 +8,17 @@ import (
 
 func TestParseBasicConsumeFrame(t *testing.T) {
 	tests := []struct {
-		name           string
-		payload        []byte
-		expectedQueue  string
-		expectedTag    string
-		expectedNoLocal bool
-		expectedNoAck  bool
+		name              string
+		payload           []byte
+		expectedQueue     string
+		expectedTag       string
+		expectedNoLocal   bool
+		expectedNoAck     bool
 		expectedExclusive bool
-		expectedNoWait bool
-		expectedArgs   map[string]any
-		shouldError    bool
-		errorMsg       string
+		expectedNoWait    bool
+		expectedArgs      map[string]any
+		shouldError       bool
+		errorMsg          string
 	}{
 		{
 			name: "Valid basic consume with empty queue and tag",
@@ -90,7 +90,7 @@ func TestParseBasicConsumeFrame(t *testing.T) {
 				Exclusive:   false,
 				NoWait:      false,
 				Arguments: map[string]any{
-					"x-priority": int32(10),
+					"x-priority":    int32(10),
 					"x-message-ttl": int32(60000),
 				},
 			}),
@@ -101,7 +101,7 @@ func TestParseBasicConsumeFrame(t *testing.T) {
 			expectedExclusive: false,
 			expectedNoWait:    false,
 			expectedArgs: map[string]any{
-				"x-priority": int32(10),
+				"x-priority":    int32(10),
 				"x-message-ttl": int32(60000),
 			},
 			shouldError: false,
@@ -116,8 +116,8 @@ func TestParseBasicConsumeFrame(t *testing.T) {
 				Exclusive:   false,
 				NoWait:      false,
 				Arguments: map[string]any{
-					"x-prefetch-count": int32(100),
-					"x-consumer-timeout": int32(30000),
+					"x-prefetch-count":        int32(100),
+					"x-consumer-timeout":      int32(30000),
 					"x-cancel-on-ha-failover": true,
 				},
 			}),
@@ -128,8 +128,8 @@ func TestParseBasicConsumeFrame(t *testing.T) {
 			expectedExclusive: false,
 			expectedNoWait:    false,
 			expectedArgs: map[string]any{
-				"x-prefetch-count": int32(100),
-				"x-consumer-timeout": int32(30000),
+				"x-prefetch-count":        int32(100),
+				"x-consumer-timeout":      int32(30000),
 				"x-cancel-on-ha-failover": true,
 			},
 			shouldError: false,
@@ -292,7 +292,7 @@ func buildBasicConsumePayload(t *testing.T, params BasicConsumeParams) []byte {
 		flags |= 0x01 // bit 0
 	}
 	if params.NoAck {
-		flags |= 0x02 // bit 1  
+		flags |= 0x02 // bit 1
 	}
 	if params.Exclusive {
 		flags |= 0x04 // bit 2
@@ -307,12 +307,12 @@ func buildBasicConsumePayload(t *testing.T, params BasicConsumeParams) []byte {
 	// arguments (table encoded as longstr)
 	if params.Arguments != nil {
 		tableData := EncodeTable(params.Arguments)
-		
+
 		// Write table length (4 bytes)
 		if err := binary.Write(&buf, binary.BigEndian, uint32(len(tableData))); err != nil {
 			t.Fatalf("Failed to write arguments length: %v", err)
 		}
-		
+
 		// Write table data
 		if _, err := buf.Write(tableData); err != nil {
 			t.Fatalf("Failed to write arguments data: %v", err)
@@ -329,7 +329,7 @@ func TestParseBasicConsumeFrame_EdgeCases(t *testing.T) {
 		for i := range longQueue {
 			longQueue = longQueue[:i] + "q" + longQueue[i+1:]
 		}
-		
+
 		payload := buildBasicConsumePayload(t, BasicConsumeParams{
 			Queue:       longQueue,
 			ConsumerTag: "consumer",
@@ -456,3 +456,224 @@ func TestParseBasicConsumeFrame_ArgumentsEdgeCases(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateBasicDeliverFrame(t *testing.T) {
+	tests := []struct {
+		name        string
+		channel     uint16
+		consumerTag string
+		exchange    string
+		routingKey  string
+		deliveryTag uint64
+		redelivered bool
+	}{
+		{
+			name:        "Standard deliver frame",
+			channel:     1,
+			consumerTag: "test-consumer",
+			exchange:    "test-exchange",
+			routingKey:  "test.routing.key",
+			deliveryTag: 123,
+			redelivered: false,
+		},
+		{
+			name:        "Redelivered message",
+			channel:     2,
+			consumerTag: "consumer-2",
+			exchange:    "amq.direct",
+			routingKey:  "redelivered.key",
+			deliveryTag: 456,
+			redelivered: true,
+		},
+		{
+			name:        "Empty exchange and routing key",
+			channel:     0,
+			consumerTag: "empty-consumer",
+			exchange:    "",
+			routingKey:  "",
+			deliveryTag: 0,
+			redelivered: false,
+		},
+		{
+			name:        "High delivery tag",
+			channel:     65535,
+			consumerTag: "high-tag-consumer",
+			exchange:    "high.exchange",
+			routingKey:  "high.routing",
+			deliveryTag: 18446744073709551615, // max uint64
+			redelivered: true,
+		},
+		{
+			name:        "Long consumer tag",
+			channel:     10,
+			consumerTag: "very-long-consumer-tag-with-many-characters",
+			exchange:    "long.exchange.name.with.dots",
+			routingKey:  "long.routing.key.with.many.segments",
+			deliveryTag: 999999,
+			redelivered: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the function under test
+			frame := createBasicDeliverFrame(tt.channel, tt.consumerTag, tt.exchange, tt.routingKey, tt.deliveryTag, tt.redelivered)
+
+			// Verify frame is not empty
+			if len(frame) == 0 {
+				t.Error("Expected non-empty frame")
+				return
+			}
+
+			// Basic frame structure validation - should start with frame type and channel
+			if len(frame) < 8 { // Minimum AMQP frame header size
+				t.Errorf("Frame too short: %d bytes", len(frame))
+				return
+			}
+
+			// Verify frame type (METHOD frame = 1)
+			if frame[0] != 1 {
+				t.Errorf("Expected frame type 1 (METHOD), got %d", frame[0])
+			}
+
+			// Verify channel (bytes 1-2, big-endian)
+			frameChannel := uint16(frame[1])<<8 | uint16(frame[2])
+			if frameChannel != tt.channel {
+				t.Errorf("Expected channel %d, got %d", tt.channel, frameChannel)
+			}
+
+			// Verify the frame contains expected class and method IDs
+			// This would require parsing the full frame, but we can at least
+			// verify the frame was created without panicking and has reasonable size
+			expectedMinSize := 8 + // frame header
+				2 + // class ID
+				2 + // method ID
+				1 + len(tt.consumerTag) + // consumer tag (shortstr)
+				8 + // delivery tag (longlong)
+				1 + // redelivered (bit, packed in octet)
+				1 + len(tt.exchange) + // exchange (shortstr)
+				1 + len(tt.routingKey) + // routing key (shortstr)
+				1 // frame end
+
+			if len(frame) < expectedMinSize {
+				t.Errorf("Frame smaller than expected minimum size. Got %d, expected at least %d", len(frame), expectedMinSize)
+			}
+
+			// Verify frame ends with frame-end byte (0xCE)
+			if frame[len(frame)-1] != 0xCE {
+				t.Errorf("Expected frame to end with 0xCE, got 0x%02X", frame[len(frame)-1])
+			}
+		})
+	}
+}
+
+func TestCreateBasicDeliverFrame_ContentStructure(t *testing.T) {
+	// Test that the function creates the correct internal structure
+	channel := uint16(5)
+	consumerTag := "test-consumer"
+	exchange := "test-exchange"
+	routingKey := "test.key"
+	deliveryTag := uint64(789)
+	redelivered := true
+
+	frame := createBasicDeliverFrame(channel, consumerTag, exchange, routingKey, deliveryTag, redelivered)
+
+	// Verify frame is created
+	if frame == nil {
+		t.Fatal("Frame should not be nil")
+	}
+
+	if len(frame) == 0 {
+		t.Fatal("Frame should not be empty")
+	}
+
+	// The function should create a ResponseMethodMessage internally with:
+	// - Channel: 5
+	// - ClassID: BASIC (60)
+	// - MethodID: BASIC_DELIVER
+	// - Content: ContentList with 5 KeyValue pairs
+
+	// We can't directly inspect the internal structure without exposing it,
+	// but we can verify the frame has the expected characteristics
+	t.Logf("Generated frame length: %d bytes", len(frame))
+	t.Logf("Frame starts with: %v", frame[:min(10, len(frame))])
+	t.Logf("Frame ends with: %v", frame[max(0, len(frame)-5):])
+}
+
+func TestCreateBasicDeliverFrame_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		channel     uint16
+		consumerTag string
+		exchange    string
+		routingKey  string
+		deliveryTag uint64
+		redelivered bool
+		description string
+	}{
+		{
+			name:        "Zero values",
+			channel:     0,
+			consumerTag: "",
+			exchange:    "",
+			routingKey:  "",
+			deliveryTag: 0,
+			redelivered: false,
+			description: "All minimum/zero values should work",
+		},
+		{
+			name:        "Single character strings",
+			channel:     1,
+			consumerTag: "c",
+			exchange:    "e",
+			routingKey:  "r",
+			deliveryTag: 1,
+			redelivered: true,
+			description: "Single character strings should work",
+		},
+		{
+			name:        "Max channel value",
+			channel:     65535,
+			consumerTag: "max-channel-consumer",
+			exchange:    "max.exchange",
+			routingKey:  "max.key",
+			deliveryTag: 12345,
+			redelivered: false,
+			description: "Maximum channel value should work",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Should not panic
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Function panicked: %v", r)
+				}
+			}()
+
+			frame := createBasicDeliverFrame(tt.channel, tt.consumerTag, tt.exchange, tt.routingKey, tt.deliveryTag, tt.redelivered)
+
+			if len(frame) == 0 {
+				t.Errorf("Expected non-empty frame for case: %s", tt.description)
+			}
+
+			// Verify basic frame structure
+			if len(frame) < 8 {
+				t.Errorf("Frame too short for case: %s", tt.description)
+			}
+
+			// Verify frame type
+			if frame[0] != 1 {
+				t.Errorf("Expected METHOD frame type for case: %s", tt.description)
+			}
+
+			// Verify frame end marker
+			if frame[len(frame)-1] != 0xCE {
+				t.Errorf("Expected frame end marker for case: %s", tt.description)
+			}
+		})
+	}
+}
+
+// Helper functions for min/max (if not available in your Go version)

--- a/internal/core/amqp/basic_test.go
+++ b/internal/core/amqp/basic_test.go
@@ -545,7 +545,7 @@ func TestCreateBasicDeliverFrame(t *testing.T) {
 			// Verify the frame contains expected class and method IDs
 			// This would require parsing the full frame, but we can at least
 			// verify the frame was created without panicking and has reasonable size
-			expectedMinSize := 8 + // frame header
+			expectedMinSize := 7 + // frame header (1 byte type + 2 bytes channel + 4 bytes payload size)
 				2 + // class ID
 				2 + // method ID
 				1 + len(tt.consumerTag) + // consumer tag (shortstr)

--- a/internal/core/amqp/connection.go
+++ b/internal/core/amqp/connection.go
@@ -96,7 +96,7 @@ func createConnectionStartFrame(configurations *map[string]any) []byte {
 	EncodeLongStr(&payloadBuf, []byte(localesSlice[0]))
 
 	frame := formatMethodFrame(channelNum, classID, methodID, payloadBuf.Bytes())
-	log.Printf("[DEBUG] Sending CONNECTION_START frame: %v", frame)
+	log.Trace().Msgf("Sending CONNECTION_START frame: %v", frame)
 	return frame
 }
 

--- a/internal/core/amqp/decode.go
+++ b/internal/core/amqp/decode.go
@@ -217,6 +217,13 @@ func min(a, b int) int {
 	return b
 }
 
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 func DecodeSecurityPlain(buf *bytes.Reader) (string, error) {
 	var strLen uint32
 	err := binary.Read(buf, binary.BigEndian, &strLen)

--- a/internal/core/amqp/framer.go
+++ b/internal/core/amqp/framer.go
@@ -10,8 +10,11 @@ type Framer interface {
 	SendFrame(conn net.Conn, frame []byte) error
 	Handshake(configurations *map[string]any, conn net.Conn, connCtxt context.Context) (*ConnectionInfo, error)
 	ParseFrame(frame []byte) (any, error)
+	CreateHeaderFrame(channel, classID uint16, msg Message) []byte
+	CreateBodyFrame(channel uint16, content []byte) []byte
 
 	// Basic Methods
+	CreateBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte
 	CreateBasicGetEmptyFrame(request *RequestMethodMessage) []byte
 	CreateBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte
 	CreateBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte
@@ -35,10 +38,6 @@ type Framer interface {
 	CreateCloseFrame(channel, replyCode, classID, methodID, closeClassID, closeClassMethod uint16, replyText string) []byte
 }
 
-func (d *DefaultFramer) CreateBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte {
-	return createBasicConsumeOkFrame(request, consumerTag)
-}
-
 type DefaultFramer struct{}
 
 func (d *DefaultFramer) ReadFrame(conn net.Conn) ([]byte, error) {
@@ -56,6 +55,16 @@ func (d *DefaultFramer) Handshake(configurations *map[string]any, conn net.Conn,
 func (d *DefaultFramer) ParseFrame(frame []byte) (any, error) {
 	return parseFrame(frame)
 }
+
+func (d *DefaultFramer) CreateHeaderFrame(channel, classID uint16, msg Message) []byte {
+	return createHeaderFrame(channel, classID, msg)
+}
+
+func (d *DefaultFramer) CreateBodyFrame(channel uint16, content []byte) []byte {
+	return createBodyFrame(channel, content)
+}
+
+// Queue Methods
 
 func (d *DefaultFramer) CreateQueueDeclareFrame(request *RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte {
 	return createQueueDeclareFrame(request, queueName, messageCount, consumerCount)
@@ -87,6 +96,14 @@ func (d *DefaultFramer) CreateConnectionCloseOkFrame(request *RequestMethodMessa
 
 func (d *DefaultFramer) CreateChannelCloseOkFrame(channel uint16) []byte {
 	return createChannelCloseOkFrame(channel)
+}
+
+func (d *DefaultFramer) CreateBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte {
+	return createBasicDeliverFrame(channel, consumerTag, exchange, routingKey, deliveryTag, redelivered)
+}
+
+func (d *DefaultFramer) CreateBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte {
+	return createBasicConsumeOkFrame(request, consumerTag)
 }
 
 func (d *DefaultFramer) CreateBasicGetEmptyFrame(request *RequestMethodMessage) []byte {

--- a/internal/core/amqp/handshake.go
+++ b/internal/core/amqp/handshake.go
@@ -21,7 +21,7 @@ func handshake(configurations *map[string]any, conn net.Conn, connCtx context.Co
 	if err != nil {
 		return nil, err
 	}
-	log.Debug().Str("header", fmt.Sprintf("%x", clientHeader)).Msg("Handshake - Received")
+	log.Trace().Str("header", fmt.Sprintf("%x", clientHeader)).Msg("Handshake - Received")
 	protocol := (*configurations)["protocol"].(string)
 	protocolHeader, err := buildProtocolHeader(protocol)
 	if err != nil {
@@ -51,7 +51,7 @@ func handshake(configurations *map[string]any, conn net.Conn, connCtx context.Co
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("\n[DEBUG] - Handshake - Received: %x\n", frame)
+	log.Trace().Msgf("Handshake - Received: %x\n", frame)
 	response, err := parseFrame(frame)
 	if err != nil {
 		return nil, err
@@ -286,7 +286,7 @@ func readFrame(conn net.Conn) ([]byte, error) {
 }
 
 func sendFrame(conn net.Conn, frame []byte) error {
-	log.Printf("[TRACE] Sending frame: %x\n", frame)
+	log.Trace().Msgf("Sending frame: %x\n", frame)
 	_, err := conn.Write(frame)
 	return err
 }

--- a/internal/core/amqp/message.go
+++ b/internal/core/amqp/message.go
@@ -64,13 +64,13 @@ type KeyValue struct {
 }
 
 func (rc ResponseContent) FormatHeaderFrame() []byte {
-	return formatHeaderFrame_(rc.Channel, rc.ClassID, rc.Weight, rc.Message)
+	return createHeaderFrame(rc.Channel, rc.ClassID, rc.Message)
 }
 
-func formatHeaderFrame_(channel, classID, weight uint16, msg Message) []byte {
+func createHeaderFrame(channel, classID uint16, msg Message) []byte {
 	frameType := uint8(TYPE_HEADER)
 	var payloadBuf bytes.Buffer
-
+	weight := uint16(0) // amqp-0-9-1 spec says "weight field is unused and must be zero"
 	bodySize := len(msg.Body)
 	flag_list, flags, err := msg.Properties.encodeBasicProperties()
 	if err != nil {
@@ -94,10 +94,12 @@ func formatHeaderFrame_(channel, classID, weight uint16, msg Message) []byte {
 }
 
 func (rc ResponseContent) FormatBodyFrame() []byte {
+	return createBodyFrame(rc.Channel, rc.Message.Body)
+}
+
+func createBodyFrame(channel uint16, content []byte) []byte {
 	frameType := uint8(TYPE_BODY)
 	var payloadBuf bytes.Buffer
-	channel := rc.Channel
-	content := rc.Message.Body
 	payloadBuf.Write(content)
 
 	payloadSize := uint32(payloadBuf.Len())

--- a/internal/core/amqp/message.go
+++ b/internal/core/amqp/message.go
@@ -63,15 +63,16 @@ type KeyValue struct {
 	Value interface{}
 }
 
-func (msg ResponseContent) FormatHeaderFrame() []byte {
+func (rc ResponseContent) FormatHeaderFrame() []byte {
+	return formatHeaderFrame_(rc.Channel, rc.ClassID, rc.Weight, rc.Message)
+}
+
+func formatHeaderFrame_(channel, classID, weight uint16, msg Message) []byte {
 	frameType := uint8(TYPE_HEADER)
 	var payloadBuf bytes.Buffer
-	channel := msg.Channel
-	classID := msg.ClassID
 
-	weight := msg.Weight
-	bodySize := len(msg.Message.Body)
-	flag_list, flags, err := msg.Message.Properties.encodeBasicProperties()
+	bodySize := len(msg.Body)
+	flag_list, flags, err := msg.Properties.encodeBasicProperties()
 	if err != nil {
 		log.Error().Err(err).Msg("Error")
 		return nil
@@ -92,11 +93,11 @@ func (msg ResponseContent) FormatHeaderFrame() []byte {
 	return frame
 }
 
-func (msg ResponseContent) FormatBodyFrame() []byte {
+func (rc ResponseContent) FormatBodyFrame() []byte {
 	frameType := uint8(TYPE_BODY)
 	var payloadBuf bytes.Buffer
-	channel := msg.Channel
-	content := msg.Message.Body
+	channel := rc.Channel
+	content := rc.Message.Body
 	payloadBuf.Write(content)
 
 	payloadSize := uint32(payloadBuf.Len())

--- a/internal/core/amqp/parsers.go
+++ b/internal/core/amqp/parsers.go
@@ -266,7 +266,7 @@ func parseConnectionMethod(methodID uint16, payload []byte) (any, error) {
 		if !ok {
 			return nil, fmt.Errorf("invalid message content type")
 		}
-		log.Printf("[TRACE] Received CONNECTION_CLOSE: (%d) '%s'", content.ReplyCode, content.ReplyText)
+		log.Debug().Msgf("Received CONNECTION_CLOSE: (%d) '%s'", content.ReplyCode, content.ReplyText)
 		return request, nil
 
 	case uint16(CONNECTION_CLOSE_OK):

--- a/internal/core/amqp/parsers.go
+++ b/internal/core/amqp/parsers.go
@@ -39,11 +39,11 @@ func parseFrame(frame []byte) (any, error) {
 		return parseBodyFrame(channel, payloadSize, payload)
 
 	case byte(TYPE_HEARTBEAT):
-		log.Printf("[TRACE] Received HEARTBEAT frame on channel %d\n", channel)
+		log.Trace().Msg("Received HEARTBEAT frame")
 		return &Heartbeat{}, nil
 
 	default:
-		log.Printf("[TRACE] Received: %x\n", frame)
+		log.Trace().Bytes("frame", frame).Msg("Received unknown frame")
 		return nil, fmt.Errorf("unknown frame type: %d", frameType)
 	}
 }
@@ -59,7 +59,7 @@ func parseMethodFrame(channel uint16, payload []byte) (*ChannelState, error) {
 
 	switch classID {
 	case uint16(CONNECTION):
-		log.Printf("[DEBUG] Received CONNECTION frame on channel %d\n", channel)
+		log.Trace().Msgf("Received CONNECTION frame on channel %d\n", channel)
 		startOkFrame, err := parseConnectionMethod(methodID, methodPayload)
 		if err != nil {
 			return nil, err
@@ -77,7 +77,7 @@ func parseMethodFrame(channel uint16, payload []byte) (*ChannelState, error) {
 		return state, nil
 
 	case uint16(CHANNEL):
-		log.Printf("[DEBUG] Received CHANNEL frame on channel %d\n", channel)
+		log.Trace().Msgf("Received CHANNEL frame on channel %d\n", channel)
 		request, err := parseChannelMethod(methodID, methodPayload)
 		if err != nil {
 			return nil, err
@@ -97,7 +97,7 @@ func parseMethodFrame(channel uint16, payload []byte) (*ChannelState, error) {
 		return nil, nil
 
 	case uint16(EXCHANGE):
-		log.Printf("[DEBUG] Received EXCHANGE frame on channel %d\n", channel)
+		log.Trace().Msgf("Received EXCHANGE frame on channel %d\n", channel)
 		request, err := parseExchangeMethod(methodID, methodPayload)
 		if err != nil {
 			return nil, err
@@ -117,7 +117,7 @@ func parseMethodFrame(channel uint16, payload []byte) (*ChannelState, error) {
 		return nil, nil
 
 	case uint16(QUEUE):
-		log.Printf("[DEBUG] Received QUEUE frame on channel %d\n", channel)
+		log.Trace().Msgf("Received QUEUE frame on channel %d\n", channel)
 		request, err := parseQueueMethod(methodID, methodPayload)
 		if err != nil {
 			return nil, err
@@ -137,7 +137,7 @@ func parseMethodFrame(channel uint16, payload []byte) (*ChannelState, error) {
 		return nil, nil
 
 	case uint16(BASIC):
-		log.Printf("[DEBUG] Received BASIC frame on channel %d\n", channel)
+		log.Debug().Uint16("channel", channel).Msg("Received BASIC frame")
 		request, err := parseBasicMethod(methodID, methodPayload)
 		if err != nil {
 			return nil, err
@@ -157,7 +157,7 @@ func parseMethodFrame(channel uint16, payload []byte) (*ChannelState, error) {
 		return nil, nil
 
 	default:
-		log.Printf("[DEBUG] Unknown class ID: %d\n", classID)
+		log.Warn().Uint16("class_id", classID).Msg("Unknown class ID")
 		return nil, fmt.Errorf("unknown class ID: %d", classID)
 	}
 }
@@ -167,14 +167,14 @@ func parseHeaderFrame(channel uint16, payloadSize uint32, payload []byte) (*Chan
 	if len(payload) < int(payloadSize) {
 		return nil, fmt.Errorf("payload too short")
 	}
-	log.Printf("[DEBUG] payload size: %d\n", payloadSize)
+	log.Trace().Uint32("payload_size", payloadSize).Msg("Received payload size")
 
 	classID := binary.BigEndian.Uint16(payload[0:2])
 
 	switch classID {
 
 	case uint16(BASIC):
-		log.Printf("[DEBUG] Received BASIC HEADER frame on channel %d\n", channel)
+		log.Debug().Uint16("channel", channel).Msg("Received BASIC HEADER frame")
 		request, err := parseBasicHeader(payload)
 		if err != nil {
 			return nil, err
@@ -189,7 +189,7 @@ func parseHeaderFrame(channel uint16, payloadSize uint32, payload []byte) (*Chan
 		return nil, nil
 
 	default:
-		log.Printf("[DEBUG] Unknown class ID: %d\n", classID)
+		log.Warn().Uint16("class_id", classID).Msg("Unknown class ID")
 		return nil, fmt.Errorf("unknown class ID: %d", classID)
 	}
 }
@@ -199,9 +199,7 @@ func parseBodyFrame(channel uint16, payloadSize uint32, payload []byte) (*Channe
 	if len(payload) < int(payloadSize) {
 		return nil, fmt.Errorf("payload too short")
 	}
-	log.Printf("[DEBUG] payload size: %d\n", payloadSize)
-
-	log.Printf("[DEBUG] Received BASIC HEADER frame on channel %d\n", channel)
+	log.Trace().Uint32("payload_size", payloadSize).Msg("Received payload size")
 
 	state := &ChannelState{
 		Body: payload,
@@ -214,10 +212,10 @@ func parseBodyFrame(channel uint16, payloadSize uint32, payload []byte) (*Channe
 func parseExchangeMethod(methodID uint16, payload []byte) (interface{}, error) {
 	switch methodID {
 	case uint16(EXCHANGE_DECLARE):
-		log.Printf("[DEBUG] Received EXCHANGE_DECLARE frame \n")
+		log.Debug().Msg("Received EXCHANGE_DECLARE frame \n")
 		return parseExchangeDeclareFrame(payload)
 	case uint16(EXCHANGE_DELETE):
-		log.Printf("[DEBUG] Received EXCHANGE_DELETE frame \n")
+		log.Debug().Msg("Received EXCHANGE_DELETE frame \n")
 		return parseExchangeDeleteFrame(payload)
 
 	default:
@@ -230,15 +228,15 @@ func parseExchangeMethod(methodID uint16, payload []byte) (interface{}, error) {
 func parseConnectionMethod(methodID uint16, payload []byte) (any, error) {
 	switch methodID {
 	case uint16(CONNECTION_START):
-		log.Printf("[DEBUG] Received CONNECTION_START frame \n")
+		log.Debug().Msg("Received CONNECTION_START frame")
 		return parseConnectionStartFrame(payload)
 
 	case uint16(CONNECTION_START_OK):
-		log.Printf("[DEBUG] Received connection.start-ok: %x\n", payload)
+		log.Trace().Bytes("payload", payload).Msg("Received connection.start-ok")
 		return parseConnectionStartOkFrame(payload)
 
 	case uint16(CONNECTION_TUNE):
-		log.Printf("[DEBUG] Received CONNECTION_TUNE_OK frame \n")
+		log.Debug().Msg("Received CONNECTION_TUNE frame")
 		tuneResponse, err := parseConnectionTuneFrame(payload)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse connection.tune frame: %v", err)
@@ -247,15 +245,15 @@ func parseConnectionMethod(methodID uint16, payload []byte) (any, error) {
 		return tuneOkRequest, nil
 
 	case uint16(CONNECTION_TUNE_OK):
-		log.Printf("[DEBUG] Received CONNECTION_TUNE_OK frame \n")
+		log.Debug().Msg("Received CONNECTION_TUNE_OK frame")
 		return parseConnectionTuneOkFrame(payload)
 
 	case uint16(CONNECTION_OPEN):
-		log.Printf("[DEBUG] Received CONNECTION_OPEN frame \n")
+		log.Debug().Msg("Received CONNECTION_OPEN frame")
 		return parseConnectionOpenFrame(payload)
 
 	case uint16(CONNECTION_OPEN_OK):
-		log.Printf("[DEBUG] Received CONNECTION_OPEN frame \n")
+		log.Debug().Msg("Received CONNECTION_OPEN_OK frame")
 		return parseConnectionOpenOkFrame(payload)
 
 	case uint16(CONNECTION_CLOSE):
@@ -277,7 +275,7 @@ func parseConnectionMethod(methodID uint16, payload []byte) (any, error) {
 			return nil, fmt.Errorf("failed to parse CONNECTION_CLOSE_OK frame: %v", err)
 		}
 		request.MethodID = methodID
-		log.Printf("[TRACE] Received CONNECTION_CLOSE_OK")
+		log.Debug().Msg("Received CONNECTION_CLOSE_OK")
 		return request, nil
 
 	default:
@@ -309,7 +307,7 @@ func parseConnectionCloseFrame(payload []byte) (*RequestMethodMessage, error) {
 	request := &RequestMethodMessage{
 		Content: msg,
 	}
-	log.Printf("[DEBUG] connection close request: %+v\n", request)
+	log.Trace().Msgf("connection close request: %+v\n", request)
 	return request, nil
 }
 
@@ -401,13 +399,13 @@ func parseConnectionStartFrame(payload []byte) (*ConnectionStartFrame, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode version-major: %v", err)
 	}
-	// log.Printf("[DEBUG] Version Major: %d\n", versionMajor)
+	log.Trace().Msgf("Version Major: %d\n", versionMajor)
 
 	versionMinor, err := buf.ReadByte()
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode version-minor: %v", err)
 	}
-	// log.Printf("[DEBUG] Version Minor: %d\n", versionMinor)
+	log.Trace().Msgf("Version Minor: %d\n", versionMinor)
 
 	/***Server Properties*/
 	serverPropertiesStr, err := DecodeLongStr(buf)
@@ -418,21 +416,21 @@ func parseConnectionStartFrame(payload []byte) (*ConnectionStartFrame, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode client properties: %v", err)
 	}
-	// log.Printf("[DEBUG] Server Properties: %+v\n", serverProperties)
+	log.Trace().Msgf("Server Properties: %+v\n", serverProperties)
 
 	/***Mechanisms*/
 	mechanismsStr, err := DecodeLongStr(buf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode mechanism: %v", err)
 	}
-	// log.Printf("[DEBUG] Mechanisms Srt: %s\n", mechanismsStr)
+	log.Trace().Msgf("Mechanisms: %s\n", mechanismsStr)
 
 	/***Locales*/
 	localesStr, err := DecodeLongStr(buf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode locale: %v", err)
 	}
-	// log.Printf("[DEBUG] Locales Srt: %s\n", localesStr)
+	log.Trace().Msgf("Locales: %s\n", localesStr)
 
 	return &ConnectionStartFrame{
 		VersionMajor:     versionMajor,
@@ -491,19 +489,19 @@ func parseConnectionStartOkFrame(payload []byte) (*ConnectionStartOk, error) {
 func parseChannelMethod(methodID uint16, payload []byte) (interface{}, error) {
 	switch methodID {
 	case uint16(CHANNEL_OPEN):
-		log.Printf("[DEBUG] Received CHANNEL_OPEN frame")
+		log.Debug().Msg("Received CHANNEL_OPEN frame")
 		return parseChannelOpenFrame(payload)
 
 	case uint16(CHANNEL_OPEN_OK):
-		log.Printf("[DEBUG] Received CHANNEL_OPEN_OK frame \n")
+		log.Debug().Msg("Received CHANNEL_OPEN_OK frame")
 		return parseChannelOpenOkFrame(payload)
 
 	case uint16(CHANNEL_CLOSE):
-		log.Printf("[DEBUG] Received CHANNEL_CLOSE frame \n")
+		log.Debug().Msg("Received CHANNEL_CLOSE frame")
 		return parseChannelCloseFrame(payload)
 
 	case uint16(CHANNEL_CLOSE_OK):
-		log.Printf("[DEBUG] Received CHANNEL_CLOSE_OK frame \n")
+		log.Debug().Msg("Received CHANNEL_CLOSE_OK frame")
 		return parseChannelCloseOkFrame(payload)
 
 	default:
@@ -534,7 +532,7 @@ func parseChannelOpenOkFrame(payload []byte) (*RequestMethodMessage, error) {
 }
 
 func parseChannelCloseFrame(payload []byte) (*RequestMethodMessage, error) {
-	log.Printf("[DEBUG] Received CHANNEL_CLOSE frame: %x \n", payload)
+	log.Trace().Msgf("Received CHANNEL_CLOSE frame: %x \n", payload)
 	if len(payload) < 6 {
 		return nil, fmt.Errorf("frame too short")
 	}

--- a/internal/core/broker/basic.go
+++ b/internal/core/broker/basic.go
@@ -164,6 +164,7 @@ func (b *Broker) basicConsumeHandler(request *amqp.RequestMethodMessage, conn ne
 			// This approach would be used in the other handlers as well
 			return nil, err
 		}
+		log.Debug().Str("consumer_tag", consumerTag).Msg("Sent Basic.ConsumeOk frame")
 	}
 	return nil, nil
 }

--- a/internal/core/broker/basic.go
+++ b/internal/core/broker/basic.go
@@ -26,7 +26,7 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 		}
 		if currentState.MethodFrame != request { // request is "newState.MethodFrame"
 			b.Connections[conn].Channels[channel].MethodFrame = request
-			log.Debug().Interface("state", b.getCurrentState(conn, channel)).Msg("Current state after update method")
+			log.Trace().Interface("state", b.getCurrentState(conn, channel)).Msg("Current state after update method")
 			return nil, nil
 		}
 		// if the class and method are not the same as the current state,
@@ -38,9 +38,11 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 			return nil, nil
 		}
 		if currentState.Body == nil && newState.Body != nil {
+			log.Trace().Int("body_len", len(newState.Body)).Uint64("expected", currentState.BodySize).Msg("Updating body")
+			// Append the new body to the current body
 			b.Connections[conn].Channels[channel].Body = newState.Body
 		}
-		log.Debug().Interface("state", currentState).Msg("Current state after all")
+		log.Trace().Interface("state", currentState).Msg("Current state after all")
 		if currentState.MethodFrame.Content != nil && currentState.HeaderFrame != nil && currentState.BodySize > 0 && currentState.Body != nil {
 			log.Debug().Interface("state", currentState).Msg("All fields must be filled")
 			if len(currentState.Body) != int(currentState.BodySize) {

--- a/internal/core/broker/basic_test.go
+++ b/internal/core/broker/basic_test.go
@@ -50,6 +50,16 @@ func (m *MockFramer) Handshake(configurations *map[string]any, conn net.Conn, co
 	return nil, nil
 }
 func (m *MockFramer) ParseFrame(frame []byte) (any, error) { return nil, nil }
+func (m *MockFramer) CreateHeaderFrame(channel, classID uint16, msg amqp.Message) []byte {
+	return []byte("header-frame")
+}
+func (m *MockFramer) CreateBodyFrame(channel uint16, content []byte) []byte {
+	return []byte("body-frame")
+}
+
+func (m *MockFramer) CreateBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte {
+	return []byte("basic-deliver")
+}
 func (m *MockFramer) CreateBasicGetEmptyFrame(request *amqp.RequestMethodMessage) []byte {
 	return []byte("basic-get-empty")
 }

--- a/internal/core/broker/broker.go
+++ b/internal/core/broker/broker.go
@@ -60,6 +60,7 @@ func NewBroker(config *config.Config, rootCtx context.Context, rootCancel contex
 	}
 	b.VHosts["/"] = vhost.NewVhost("/", config.QueueBufferSize, b.persist)
 	b.framer = &amqp.DefaultFramer{}
+	b.VHosts["/"].SetFramer(b.framer)
 	b.ManagerApi = &DefaultManagerApi{b}
 	return b
 }

--- a/internal/core/broker/broker.go
+++ b/internal/core/broker/broker.go
@@ -199,10 +199,9 @@ func (b *Broker) processRequest(conn net.Conn, newState *amqp.ChannelState) (any
 func (b *Broker) getCurrentState(conn net.Conn, channel uint16) *amqp.ChannelState {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	log.Debug().Uint16("channel", channel).Msg("Getting current state for channel")
 	state, ok := b.Connections[conn].Channels[channel]
 	if !ok {
-		log.Debug().Msg("No channel found")
+		log.Debug().Uint16("channel", channel).Msg("No channel found")
 		return nil
 	}
 	return state

--- a/internal/core/broker/connection.go
+++ b/internal/core/broker/connection.go
@@ -71,7 +71,6 @@ func (b *Broker) handleConnection(conn net.Conn, connInfo *amqp.ConnectionInfo) 
 			request := newState.MethodFrame
 			if channelNum != request.Channel {
 				channelNum = newState.MethodFrame.Channel
-				log.Debug().Uint16("channel", request.Channel).Msg("Switching to channel")
 			}
 		} else {
 			if newState.HeaderFrame != nil {

--- a/internal/core/broker/vhost/consumer.go
+++ b/internal/core/broker/vhost/consumer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/andrelcunha/ottermq/internal/core/amqp"
 	"github.com/google/uuid"
 )
 
@@ -23,7 +24,7 @@ type Consumer struct {
 	Channel     uint16
 	QueueName   string
 	Connection  net.Conn
-	DeliveryTag uint64 // ?? What is this for?
+	DeliveryTag uint64 // will be incremented per delivery
 	Active      bool
 	Props       *ConsumerProperties
 }
@@ -102,6 +103,12 @@ func (vh *VHost) RegisterConsumer(consumer *Consumer) error {
 		consumer,
 	)
 
+	// start delivery routine if not already running
+	queue := vh.Queues[consumer.QueueName]
+	if len(vh.ConsumersByQueue[queue.Name]) == 1 {
+		go queue.startDeliveryLoop(vh)
+	}
+
 	return nil
 }
 
@@ -126,7 +133,8 @@ func (vh *VHost) CancelConsumer(channel uint16, tag string) error {
 		}
 	}
 	if len(vh.ConsumersByQueue[consumer.QueueName]) == 0 {
-		delete(vh.ConsumersByQueue, consumer.QueueName)
+		queue := vh.Queues[consumer.QueueName]
+		queue.stopDeliveryLoop()
 	}
 
 	// Remove from ConsumersByChannel (connection-scoped)
@@ -137,10 +145,6 @@ func (vh *VHost) CancelConsumer(channel uint16, tag string) error {
 			vh.ConsumersByChannel[channelKey] = append(consumersForChannel[:i], consumersForChannel[i+1:]...)
 			break
 		}
-	}
-	// Clean up empty channel entries
-	if len(vh.ConsumersByChannel[channelKey]) == 0 {
-		delete(vh.ConsumersByChannel, channelKey)
 	}
 
 	return nil
@@ -167,6 +171,7 @@ func (vh *VHost) CleanupChannel(connection net.Conn, channel uint16) {
 		vh.CancelConsumer(c.Channel, c.Tag)
 		vh.mu.Lock()
 	}
+	delete(vh.ConsumersByChannel, channelKey)
 }
 
 func (vh *VHost) CleanupConnection(connection net.Conn) {
@@ -188,4 +193,59 @@ func (vh *VHost) CleanupConnection(connection net.Conn) {
 		vh.CancelConsumer(consumer.Channel, consumer.Tag)
 		vh.mu.Lock()
 	}
+}
+
+func (vh *VHost) GetActiveConsumersForQueue(queueName string) []*Consumer {
+	vh.mu.Lock()
+	defer vh.mu.Unlock()
+	consumers := vh.ConsumersByQueue[queueName]
+	if consumers == nil {
+		return nil
+	}
+	// Filter only active consumers
+	activeConsumers := make([]*Consumer, 0, len(consumers))
+	for _, consumer := range consumers {
+		if consumer.Active {
+			activeConsumers = append(activeConsumers, consumer)
+		}
+	}
+	return activeConsumers
+}
+
+func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message) error {
+	// vh should not have access to framer
+	// nevertheless, i don't know how to get the framer without a circular dependency
+	if !consumer.Active {
+		return fmt.Errorf("consumer %s on channel %d is not active", consumer.Tag, consumer.Channel)
+	}
+	consumer.DeliveryTag++
+	deliverFrame := vh.framer.CreateBasicDeliverFrame(
+		consumer.Channel,
+		consumer.Tag,
+		msg.Exchange,
+		msg.RoutingKey,
+		consumer.DeliveryTag,
+		false, // redelivered - TODO: implement redelivery logic
+	)
+
+	headerFrame := vh.framer.CreateHeaderFrame(consumer.Channel, uint16(amqp.BASIC), msg)
+
+	bodyFrame := vh.framer.CreateBodyFrame(consumer.Channel, msg.Body)
+
+	if err := vh.framer.SendFrame(consumer.Connection, deliverFrame); err != nil {
+
+		return err
+	}
+	if err := vh.framer.SendFrame(consumer.Connection, headerFrame); err != nil {
+		return err
+	}
+	if err := vh.framer.SendFrame(consumer.Connection, bodyFrame); err != nil {
+		return err
+	}
+
+	// TODO: realize how to handle NoAck consumers and message acks
+	// For now, we assume all consumers are NoAck
+	// So we don't need to track unacknowledged messages
+
+	return nil
 }

--- a/internal/core/broker/vhost/consumer.go
+++ b/internal/core/broker/vhost/consumer.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/andrelcunha/ottermq/internal/core/amqp"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 )
 
 type ConsumerKey struct {
@@ -233,13 +234,15 @@ func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message) error {
 	bodyFrame := vh.framer.CreateBodyFrame(consumer.Channel, msg.Body)
 
 	if err := vh.framer.SendFrame(consumer.Connection, deliverFrame); err != nil {
-
+		log.Error().Err(err).Msg("Failed to send deliver frame")
 		return err
 	}
 	if err := vh.framer.SendFrame(consumer.Connection, headerFrame); err != nil {
+		log.Error().Err(err).Msg("Failed to send header frame")
 		return err
 	}
 	if err := vh.framer.SendFrame(consumer.Connection, bodyFrame); err != nil {
+		log.Error().Err(err).Msg("Failed to send body frame")
 		return err
 	}
 

--- a/internal/core/broker/vhost/message.go
+++ b/internal/core/broker/vhost/message.go
@@ -19,6 +19,8 @@ type SaveMessageRequest struct {
 	MsgProps   persistence.MessageProperties
 }
 
+// TODO: create a higher level abstraction of amqp.Message, exposing the content, requeued count, etc
+
 func (vh *VHost) Publish(exchangeName, routingKey string, body []byte, props *amqp.BasicProperties) (string, error) {
 	vh.mu.Lock()
 	defer vh.mu.Unlock()

--- a/internal/core/broker/vhost/message.go
+++ b/internal/core/broker/vhost/message.go
@@ -45,7 +45,7 @@ func (vh *VHost) Publish(exchangeName, routingKey string, body []byte, props *am
 		Exchange:   exchangeName,
 		RoutingKey: routingKey,
 	}
-	log.Debug().Str("id", msgID).Str("exchange", exchangeName).Str("routing_key", routingKey).Str("body", string(body)).Interface("properties", props).Msg("Publishing message")
+	log.Trace().Str("id", msgID).Str("exchange", exchangeName).Str("routing_key", routingKey).Str("body", string(body)).Interface("properties", props).Msg("Publishing message")
 
 	var timestamp int64
 	if props.Timestamp.IsZero() {

--- a/internal/core/broker/vhost/queue.go
+++ b/internal/core/broker/vhost/queue.go
@@ -1,6 +1,7 @@
 package vhost
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -18,6 +19,10 @@ type Queue struct {
 	messages chan amqp.Message `json:"-"`
 	count    int               `json:"-"`
 	mu       sync.Mutex        `json:"-"`
+	/* Delivery */
+	deliveryCtx    context.Context    `json:"-"`
+	deliveryCancel context.CancelFunc `json:"-"`
+	delivering     bool
 }
 
 type QueueProperties struct {
@@ -30,12 +35,57 @@ type QueueProperties struct {
 }
 
 func NewQueue(name string, bufferSize int) *Queue {
+
 	return &Queue{
-		Name:     name,
-		Props:    &QueueProperties{},
-		messages: make(chan amqp.Message, bufferSize),
-		count:    0,
+		Name:       name,
+		Props:      &QueueProperties{},
+		messages:   make(chan amqp.Message, bufferSize),
+		count:      0,
+		delivering: false,
 	}
+}
+
+func (q *Queue) startDeliveryLoop(vh *VHost) {
+	if q.delivering {
+		return // already running
+	}
+	q.deliveryCtx, q.deliveryCancel = context.WithCancel(context.Background())
+	q.delivering = true
+	go func() {
+		for {
+			select {
+			case <-q.deliveryCtx.Done():
+				log.Debug().Str("queue", q.Name).Msg("Stopping delivery loop")
+				q.delivering = false
+				return
+			case msg := <-q.messages:
+				// Here we would deliver the message to consumers
+				log.Debug().Str("queue", q.Name).Str("id", msg.ID).Msg("Delivering message to consumers")
+				vh.mu.Lock()
+				consumers := vh.GetActiveConsumersForQueue(q.Name)
+				if len(consumers) > 0 {
+					// Simple round-robin delivery
+					consumer := consumers[0]
+					vh.ConsumersByQueue[q.Name] = append(consumers[1:], consumer)
+					// TODO: improve delivery strategy using basic.qos and manual ack
+					if err := vh.deliverToConsumer(consumer, msg); err != nil {
+						q.ReQueue(msg) // requeue on failure
+					}
+					vh.mu.Unlock()
+				} else {
+					vh.mu.Unlock()
+				}
+			}
+		}
+	}()
+}
+
+func (q *Queue) stopDeliveryLoop() {
+	if !q.delivering {
+		return
+	}
+	q.deliveryCancel()
+	q.delivering = false
 }
 
 func (vh *VHost) CreateQueue(name string, props *QueueProperties) (*Queue, error) {


### PR DESCRIPTION
This pull request introduces several foundational changes to advance AMQP 0.9.1 support, refactor the persistence layer, and improve code structure and maintainability. The main highlights are the addition of new AMQP method frame handling (notably for `BASIC_CONSUME` and `BASIC_DELIVER`), a significant persistence package refactor, and the replacement of legacy encoding/decoding helpers with new implementations. The roadmap and documentation are also updated to reflect current priorities and architectural plans.

**AMQP Method Frame Handling and Structs:**

- Added `BasicConsumeContent` and `BasicPublishContent` structs to clarify the structure of AMQP method payloads and facilitate future `BASIC_CONSUME` implementation. (`internal/core/amqp/basic.go`)
- Implemented helpers for formatting `BASIC_CONSUME_OK` and `BASIC_DELIVER` frames, improving the broker's ability to communicate with clients per AMQP protocol. (`internal/core/amqp/basic.go`)
- Updated method parsing logic to recognize and route `BASIC_CONSUME` and `BASIC_QOS` frames, setting the stage for full consumer management. (`internal/core/amqp/basic.go`)

**Persistence Layer Refactor:**

- Moved persistence code from `internal/core/persistdb` to `internal/persistdb` and updated all imports accordingly, in preparation for a more modular and pluggable persistence backend architecture. (`cmd/ottermq/main.go`, `.github/copilot-instructions.md`) [[1]](diffhunk://#diff-61e815c22d1fc2679b2dbd58d60ab474167dd3ef00e20845a93a3b5828fb246eL14-R14) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L35-R36)
- Improved error handling for user creation and database opening, logging errors instead of failing silently. (`cmd/ottermq/main.go`)

**Encoding/Decoding Improvements:**

- Replaced legacy encoding helpers (`encodeShortStr`, `encodeTable`, etc.) with new, consistently named functions (`EncodeShortStr`, `EncodeTable`, etc.), simplifying the code and error handling for property serialization. (`internal/core/amqp/basic.go`)
- Updated logging in AMQP header parsing to use structured logging (`zerolog`) at the trace level for better debugging and observability. (`internal/core/amqp/basic.go`) [[1]](diffhunk://#diff-4441fbe1356466d2741ee4594d78ea444265bace4757a39eef2efffaf1c47d18L300-R268) [[2]](diffhunk://#diff-4441fbe1356466d2741ee4594d78ea444265bace4757a39eef2efffaf1c47d18L317-R279)

**Documentation and Roadmap Updates:**

- Expanded `ROADMAP.md` with detailed development phases, architecture improvement plans, and contribution guidelines, clarifying current priorities (notably `BASIC_CONSUME` and consumer management). [[1]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51R4-R10) [[2]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51R36-R42) [[3]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51R56) [[4]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51R77-R84) [[5]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51R95) [[6]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51R111-R118) [[7]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51R133-R221)
- Updated `.github/copilot-instructions.md` to reflect the new persistence package location and backend plans.

These changes lay the groundwork for implementing core AMQP consumer functionality and make the codebase more maintainable and extensible for future features.