### PR TITLE
Add BASIC_CANCEL frame handling and related features

### DIFF
--- a/internal/core/amqp/basic.go
+++ b/internal/core/amqp/basic.go
@@ -20,7 +20,7 @@ type BasicConsumeContent struct {
 
 type BasicCancelContent struct {
 	ConsumerTag string
-	Nowait      bool
+	NoWait      bool
 }
 
 type BasicPublishContent struct {
@@ -452,7 +452,7 @@ func parseBasicCancelFrame(payload []byte) (*RequestMethodMessage, error) {
 
 	content := &BasicCancelContent{
 		ConsumerTag: consumerTag,
-		Nowait:      nowait,
+		NoWait:      nowait,
 	}
 	request := &RequestMethodMessage{
 		Content: content,

--- a/internal/core/amqp/basic.go
+++ b/internal/core/amqp/basic.go
@@ -83,6 +83,23 @@ func createBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string
 	return frame
 }
 
+func createBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
+	keyValuePairs := []KeyValue{
+		{
+			Key:   STRING_SHORT,
+			Value: consumerTag,
+		},
+	}
+
+	frame := ResponseMethodMessage{
+		Channel:  channel,
+		ClassID:  uint16(BASIC),
+		MethodID: uint16(BASIC_CANCEL_OK),
+		Content:  ContentList{KeyValuePairs: keyValuePairs},
+	}.FormatMethodFrame()
+	return frame
+}
+
 // createBasicDeliverFrame creates a Basic.Deliver (60) frame for the given message and delivery tag.
 func createBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte {
 	consumerTagKv := KeyValue{

--- a/internal/core/amqp/basic.go
+++ b/internal/core/amqp/basic.go
@@ -66,7 +66,7 @@ type BasicProperties struct {
 	Reserved        string         // shortstr
 }
 
-func createBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte {
+func createBasicConsumeOkFrame(channel uint16, consumerTag string) []byte {
 	keyValuePairs := []KeyValue{
 		{
 			Key:   STRING_SHORT,
@@ -75,8 +75,8 @@ func createBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string
 	}
 
 	frame := ResponseMethodMessage{
-		Channel:  request.Channel,
-		ClassID:  request.ClassID,
+		Channel:  channel,
+		ClassID:  uint16(BASIC),
 		MethodID: uint16(BASIC_CONSUME_OK),
 		Content:  ContentList{KeyValuePairs: keyValuePairs},
 	}.FormatMethodFrame()
@@ -134,22 +134,22 @@ func createBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey s
 	return frame
 }
 
-func createBasicGetEmptyFrame(request *RequestMethodMessage) []byte {
+func createBasicGetEmptyFrame(channel uint16) []byte {
 	// Send Basic.GetEmpty
 	reserved1 := KeyValue{
 		Key:   STRING_SHORT,
 		Value: "",
 	}
 	frame := ResponseMethodMessage{
-		Channel:  request.Channel,
-		ClassID:  request.ClassID,
+		Channel:  channel,
+		ClassID:  uint16(BASIC),
 		MethodID: uint16(BASIC_GET_EMPTY),
 		Content:  ContentList{KeyValuePairs: []KeyValue{reserved1}},
 	}.FormatMethodFrame()
 	return frame
 }
 
-func createBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte {
+func createBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte {
 	msgGetOk := &BasicGetOkContent{
 		DeliveryTag:  1,
 		Redelivered:  false,
@@ -159,8 +159,8 @@ func createBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey s
 	}
 
 	frame := ResponseMethodMessage{
-		Channel:  request.Channel,
-		ClassID:  request.ClassID,
+		Channel:  channel,
+		ClassID:  uint16(BASIC),
 		MethodID: uint16(BASIC_GET_OK),
 		Content:  *EncodeGetOkToContentList(msgGetOk),
 	}.FormatMethodFrame()

--- a/internal/core/amqp/basic_test.go
+++ b/internal/core/amqp/basic_test.go
@@ -707,7 +707,7 @@ func TestParseBasicCancelFrame_ValidPayload(t *testing.T) {
 		t.Errorf("Expected consumer tag 'test-consumer', got '%s'", content.ConsumerTag)
 	}
 
-	if content.Nowait {
+	if content.NoWait {
 		t.Error("Expected Nowait to be false")
 	}
 }
@@ -743,7 +743,7 @@ func TestParseBasicCancelFrame_WithNowaitFlag(t *testing.T) {
 		t.Errorf("Expected consumer tag 'consumer1', got '%s'", content.ConsumerTag)
 	}
 
-	if !content.Nowait {
+	if !content.NoWait {
 		t.Error("Expected Nowait to be true")
 	}
 }
@@ -799,7 +799,7 @@ func TestParseBasicCancelFrame_LongConsumerTag(t *testing.T) {
 		t.Errorf("Expected consumer tag length %d, got %d", len(consumerTag), len(content.ConsumerTag))
 	}
 
-	if !content.Nowait {
+	if !content.NoWait {
 		t.Error("Expected Nowait to be true")
 	}
 }
@@ -858,7 +858,7 @@ func TestParseBasicCancelFrame_SingleCharacterTag(t *testing.T) {
 		t.Errorf("Expected consumer tag 'x', got '%s'", content.ConsumerTag)
 	}
 
-	if content.Nowait {
+	if content.NoWait {
 		t.Error("Expected Nowait to be false")
 	}
 }

--- a/internal/core/amqp/basic_test.go
+++ b/internal/core/amqp/basic_test.go
@@ -676,4 +676,189 @@ func TestCreateBasicDeliverFrame_EdgeCases(t *testing.T) {
 	}
 }
 
-// Helper functions for min/max (if not available in your Go version)
+func TestParseBasicCancelFrame_ValidPayload(t *testing.T) {
+	// Create a payload with consumer tag "test-consumer" and nowait=false
+	var payload []byte
+
+	// Consumer tag: "test-consumer" (12 bytes + 1 length byte)
+	consumerTag := "test-consumer"
+	payload = append(payload, byte(len(consumerTag)))
+	payload = append(payload, []byte(consumerTag)...)
+
+	// Flags: nowait=false (bit 0 = 0)
+	payload = append(payload, 0x00)
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+
+	content, ok := result.Content.(*BasicCancelContent)
+	if !ok {
+		t.Fatalf("Expected BasicCancelContent, got %T", result.Content)
+	}
+
+	if content.ConsumerTag != "test-consumer" {
+		t.Errorf("Expected consumer tag 'test-consumer', got '%s'", content.ConsumerTag)
+	}
+
+	if content.Nowait {
+		t.Error("Expected Nowait to be false")
+	}
+}
+
+func TestParseBasicCancelFrame_WithNowaitFlag(t *testing.T) {
+	// Create a payload with consumer tag "consumer1" and nowait=true
+	var payload []byte
+
+	// Consumer tag: "consumer1"
+	consumerTag := "consumer1"
+	payload = append(payload, byte(len(consumerTag)))
+	payload = append(payload, []byte(consumerTag)...)
+
+	// Flags: nowait=true (bit 0 = 1)
+	payload = append(payload, 0x01)
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+
+	content, ok := result.Content.(*BasicCancelContent)
+	if !ok {
+		t.Fatalf("Expected BasicCancelContent, got %T", result.Content)
+	}
+
+	if content.ConsumerTag != "consumer1" {
+		t.Errorf("Expected consumer tag 'consumer1', got '%s'", content.ConsumerTag)
+	}
+
+	if !content.Nowait {
+		t.Error("Expected Nowait to be true")
+	}
+}
+
+func TestParseBasicCancelFrame_PayloadTooShort(t *testing.T) {
+	// Payload with only 2 bytes (minimum is 3)
+	payload := []byte{0x01, 0x41} // length=1, 'A'
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err == nil {
+		t.Error("Expected error for payload too short")
+	}
+
+	expectedError := "payload too short"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error '%s', got '%s'", expectedError, err.Error())
+	}
+
+	if result != nil {
+		t.Error("Expected nil result")
+	}
+}
+
+func TestParseBasicCancelFrame_LongConsumerTag(t *testing.T) {
+	// Create payload with long consumer tag (255 chars - maximum for short string)
+	consumerTag := string(make([]byte, 255))
+	for i := range consumerTag {
+		consumerTag = consumerTag[:i] + "a" + consumerTag[i+1:]
+	}
+
+	var payload []byte
+	payload = append(payload, byte(len(consumerTag)))
+	payload = append(payload, []byte(consumerTag)...)
+	payload = append(payload, 0x01) // nowait=true
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+
+	content, ok := result.Content.(*BasicCancelContent)
+	if !ok {
+		t.Fatalf("Expected BasicCancelContent, got %T", result.Content)
+	}
+
+	if content.ConsumerTag != consumerTag {
+		t.Errorf("Expected consumer tag length %d, got %d", len(consumerTag), len(content.ConsumerTag))
+	}
+
+	if !content.Nowait {
+		t.Error("Expected Nowait to be true")
+	}
+}
+
+func TestParseBasicCancelFrame_MissingFlagsByte(t *testing.T) {
+	// Create payload missing the flags byte
+	var payload []byte
+
+	// Consumer tag: "test"
+	consumerTag := "test"
+	payload = append(payload, byte(len(consumerTag)))
+	payload = append(payload, []byte(consumerTag)...)
+	// Missing flags byte
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err == nil {
+		t.Error("Expected error for missing flags byte")
+	}
+
+	if !bytes.Contains([]byte(err.Error()), []byte("failed to read octet")) {
+		t.Errorf("Expected error about reading octet, got: %v", err)
+	}
+
+	if result != nil {
+		t.Error("Expected nil result")
+	}
+}
+
+func TestParseBasicCancelFrame_SingleCharacterTag(t *testing.T) {
+	// Test with minimum valid consumer tag (1 character)
+	var payload []byte
+
+	// Consumer tag: "x"
+	consumerTag := "x"
+	payload = append(payload, byte(len(consumerTag)))
+	payload = append(payload, []byte(consumerTag)...)
+	payload = append(payload, 0x00) // nowait=false
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+
+	content, ok := result.Content.(*BasicCancelContent)
+	if !ok {
+		t.Fatalf("Expected BasicCancelContent, got %T", result.Content)
+	}
+
+	if content.ConsumerTag != "x" {
+		t.Errorf("Expected consumer tag 'x', got '%s'", content.ConsumerTag)
+	}
+
+	if content.Nowait {
+		t.Error("Expected Nowait to be false")
+	}
+}

--- a/internal/core/amqp/framer.go
+++ b/internal/core/amqp/framer.go
@@ -15,11 +15,10 @@ type Framer interface {
 
 	// Basic Methods
 	CreateBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte
-	CreateBasicGetEmptyFrame(request *RequestMethodMessage) []byte
-	CreateBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte
-	CreateBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte
+	CreateBasicGetEmptyFrame(channel uint16) []byte
+	CreateBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte
+	CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte
 	CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte
-
 
 	// Queue Methods
 	CreateQueueDeclareOkFrame(request *RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte
@@ -104,16 +103,20 @@ func (d *DefaultFramer) CreateBasicDeliverFrame(channel uint16, consumerTag, exc
 	return createBasicDeliverFrame(channel, consumerTag, exchange, routingKey, deliveryTag, redelivered)
 }
 
-func (d *DefaultFramer) CreateBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte {
-	return createBasicConsumeOkFrame(request, consumerTag)
+func (d *DefaultFramer) CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte {
+	return createBasicConsumeOkFrame(channel, consumerTag)
 }
 
-func (d *DefaultFramer) CreateBasicGetEmptyFrame(request *RequestMethodMessage) []byte {
-	return createBasicGetEmptyFrame(request)
+func (d *DefaultFramer) CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
+	return createBasicCancelOkFrame(channel, consumerTag)
 }
 
-func (d *DefaultFramer) CreateBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte {
-	return createBasicGetOkFrame(request, exchange, routingkey, msgCount)
+func (d *DefaultFramer) CreateBasicGetEmptyFrame(channel uint16) []byte {
+	return createBasicGetEmptyFrame(channel)
+}
+
+func (d *DefaultFramer) CreateBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte {
+	return createBasicGetOkFrame(channel, exchange, routingkey, msgCount)
 }
 
 func (d *DefaultFramer) CreateCloseFrame(channel, replyCode, classID, methodID, closeClassID, closeClassMethod uint16, replyText string) []byte {

--- a/internal/core/amqp/framer.go
+++ b/internal/core/amqp/framer.go
@@ -18,6 +18,8 @@ type Framer interface {
 	CreateBasicGetEmptyFrame(request *RequestMethodMessage) []byte
 	CreateBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte
 	CreateBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte
+	CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte
+
 
 	// Queue Methods
 	CreateQueueDeclareOkFrame(request *RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte

--- a/internal/core/amqp/parsers.go
+++ b/internal/core/amqp/parsers.go
@@ -185,7 +185,7 @@ func parseHeaderFrame(channel uint16, payloadSize uint32, payload []byte) (*Chan
 	switch classID {
 
 	case uint16(BASIC):
-		log.Debug().Uint16("channel", channel).Msg("Received BASIC HEADER frame")
+		log.Trace().Uint16("channel", channel).Msg("Received BASIC HEADER frame")
 		request, err := parseBasicHeader(payload)
 		if err != nil {
 			return nil, err

--- a/internal/core/amqp/parsers.go
+++ b/internal/core/amqp/parsers.go
@@ -140,6 +140,17 @@ func parseMethodFrame(channel uint16, payload []byte) (*ChannelState, error) {
 		log.Debug().Uint16("channel", channel).Msg("Received BASIC frame")
 		request, err := parseBasicMethod(methodID, methodPayload)
 		if err != nil {
+			// The raised exception (connection type):
+			// (501 - "frame error"),
+			// (502 - "syntax error"),
+			// (503 - "command invalid"),
+			// (504 - "channel error"), -- shall be handled at a higher level
+			// (505 - "unexpected frame"),
+			// (506 - "resource error"), -- shall be handled at a higher level
+			// (530 - "not allowed"), -- shall be handled at a higher level
+			// (540 - "not implemented"),
+			// (541 - "internal error"),
+			//
 			return nil, err
 		}
 		if request != nil {

--- a/internal/core/broker/basic.go
+++ b/internal/core/broker/basic.go
@@ -74,7 +74,7 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 			return nil, err
 		}
 		if msgCount == 0 {
-			frame := b.framer.CreateBasicGetEmptyFrame(request)
+			frame := b.framer.CreateBasicGetEmptyFrame(request.Channel)
 			if err := b.framer.SendFrame(conn, frame); err != nil {
 				log.Error().Err(err).Msg("Failed to send basic get empty frame")
 			}
@@ -84,7 +84,7 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 		// Send Basic.GetOk + header + body
 		msg := vh.GetMessage(queue)
 
-		frame := b.framer.CreateBasicGetOkFrame(request, msg.Exchange, msg.RoutingKey, uint32(msgCount))
+		frame := b.framer.CreateBasicGetOkFrame(request.Channel, msg.Exchange, msg.RoutingKey, uint32(msgCount))
 		err = b.framer.SendFrame(conn, frame)
 		log.Debug().Str("queue", queue).Str("id", msg.ID).Msg("Sent message from queue")
 
@@ -181,7 +181,7 @@ func (b *Broker) basicConsumeHandler(request *amqp.RequestMethodMessage, conn ne
 	}
 
 	if !noWait {
-		frame := b.framer.CreateBasicConsumeOkFrame(request, consumerTag)
+		frame := b.framer.CreateBasicConsumeOkFrame(request.Channel, consumerTag)
 		if err := b.framer.SendFrame(conn, frame); err != nil {
 			log.Error().Err(err).Msg("Failed to send basic consume ok frame")
 			// Verify if should return error (as channel exception) or just log it

--- a/internal/core/broker/basic.go
+++ b/internal/core/broker/basic.go
@@ -35,7 +35,7 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 		if currentState.HeaderFrame == nil && newState.HeaderFrame != nil {
 			b.Connections[conn].Channels[channel].HeaderFrame = newState.HeaderFrame
 			b.Connections[conn].Channels[channel].BodySize = newState.HeaderFrame.BodySize
-			log.Debug().Interface("state", b.getCurrentState(conn, channel)).Msg("Current state after update header")
+			log.Trace().Interface("state", b.getCurrentState(conn, channel)).Msg("Current state after update header")
 			return nil, nil
 		}
 		if currentState.Body == nil && newState.Body != nil {
@@ -45,9 +45,9 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 		}
 		log.Trace().Interface("state", currentState).Msg("Current state after all")
 		if currentState.MethodFrame.Content != nil && currentState.HeaderFrame != nil && currentState.BodySize > 0 && currentState.Body != nil {
-			log.Debug().Interface("state", currentState).Msg("All fields must be filled")
+			log.Trace().Interface("state", currentState).Msg("All fields must be filled")
 			if len(currentState.Body) != int(currentState.BodySize) {
-				log.Debug().Int("body_len", len(currentState.Body)).Uint64("expected", currentState.BodySize).Msg("Body size is not correct")
+				log.Trace().Int("body_len", len(currentState.Body)).Uint64("expected", currentState.BodySize).Msg("Body size is not correct")
 				// TODO: handle this error properly, maybe sending the correct channel exception
 				// vide amqp.constants.go Exceptions
 				return nil, fmt.Errorf("body size is not correct: %d != %d", len(currentState.Body), currentState.BodySize)
@@ -59,7 +59,7 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 			props := currentState.HeaderFrame.Properties
 			_, err := vh.Publish(exchanege, routingKey, body, props)
 			if err == nil {
-				log.Debug().Str("exchange", exchanege).Str("routing_key", routingKey).Str("body", string(body)).Msg("Published message")
+				log.Trace().Str("exchange", exchanege).Str("routing_key", routingKey).Str("body", string(body)).Msg("Published message")
 				b.Connections[conn].Channels[channel] = &amqp.ChannelState{}
 			}
 			return nil, err

--- a/internal/core/broker/basic_test.go
+++ b/internal/core/broker/basic_test.go
@@ -60,13 +60,13 @@ func (m *MockFramer) CreateBodyFrame(channel uint16, content []byte) []byte {
 func (m *MockFramer) CreateBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte {
 	return []byte("basic-deliver")
 }
-func (m *MockFramer) CreateBasicGetEmptyFrame(request *amqp.RequestMethodMessage) []byte {
+func (m *MockFramer) CreateBasicGetEmptyFrame(channel uint16) []byte {
 	return []byte("basic-get-empty")
 }
-func (m *MockFramer) CreateBasicGetOkFrame(request *amqp.RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte {
+func (m *MockFramer) CreateBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte {
 	return []byte("basic-get-ok")
 }
-func (m *MockFramer) CreateBasicConsumeOkFrame(request *amqp.RequestMethodMessage, consumerTag string) []byte {
+func (m *MockFramer) CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte {
 	return []byte("basic-consume-ok:" + consumerTag)
 }
 func (m *MockFramer) CreateQueueDeclareOkFrame(request *amqp.RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte {

--- a/internal/core/broker/basic_test.go
+++ b/internal/core/broker/basic_test.go
@@ -69,6 +69,9 @@ func (m *MockFramer) CreateBasicGetOkFrame(channel uint16, exchange, routingkey 
 func (m *MockFramer) CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte {
 	return []byte("basic-consume-ok:" + consumerTag)
 }
+func (m *MockFramer) CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
+	return []byte("basic-cancel-ok:" + consumerTag)
+}
 func (m *MockFramer) CreateQueueDeclareOkFrame(request *amqp.RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte {
 	return []byte("queue-declare")
 }

--- a/internal/core/broker/connection.go
+++ b/internal/core/broker/connection.go
@@ -74,15 +74,15 @@ func (b *Broker) handleConnection(conn net.Conn, connInfo *amqp.ConnectionInfo) 
 			}
 		} else {
 			if newState.HeaderFrame != nil {
-				log.Debug().Interface("header", newState.HeaderFrame).Msg("HeaderFrame")
+				log.Trace().Interface("header", newState.HeaderFrame).Msg("HeaderFrame")
 			} else if newState.Body != nil {
-				log.Debug().Interface("body", newState.Body).Msg("Body")
+				log.Trace().Interface("body", newState.Body).Msg("Body")
 			}
 			if previousState, exists := b.Connections[conn].Channels[channelNum]; exists {
 				newState.MethodFrame = previousState.MethodFrame
-				log.Debug().Interface("method_frame", previousState.MethodFrame).Msg("Recovered method frame")
+				log.Trace().Interface("method_frame", previousState.MethodFrame).Msg("Recovered method frame")
 			} else {
-				log.Debug().Uint16("channel", channelNum).Msg("Channel not found")
+				log.Trace().Uint16("channel", channelNum).Msg("Channel not found")
 				continue
 			}
 		}

--- a/internal/core/broker/vhost/queue.go
+++ b/internal/core/broker/vhost/queue.go
@@ -58,7 +58,10 @@ func (q *Queue) startDeliveryLoop(vh *VHost) {
 				q.delivering = false
 				return
 			case msg := <-q.messages:
-				// Here we would deliver the message to consumers
+				q.mu.Lock()
+				q.count--
+				q.mu.Unlock()
+
 				log.Debug().Str("queue", q.Name).Str("id", msg.ID).Msg("Delivering message to consumers")
 				consumers := vh.GetActiveConsumersForQueue(q.Name)
 				if len(consumers) > 0 {


### PR DESCRIPTION
Introduce support for BASIC_CANCEL frames, including parsing and frame creation. Enhance error handling documentation and improve logging levels. Add comprehensive tests for the new functionality and ensure thread safety in message delivery. Fix minor issues and refactor frame creation methods for consistency.