### PR TITLE
Implement BASIC_CANCEL and BASIC_ACK handling with delivery tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ This uses the provided `Dockerfile` and `docker-compose.yml` for convenience.
 ## 🚧 Development Status
 OtterMq is under active development. While it follows the AMQP 0.9.1 protocol, several features are still in progress or not yet implemented, including:
 
-- `basic.consume` command for push-based message delivery
 - Message acknowledgments and recovery
 - Advanced routing and delivery guarantees
 - Memento WAL persistence engine (planned)
+
+**Push-based message consumption (`basic.consume`/`basic.deliver`) is now fully implemented and compatible with RabbitMQ clients.**
 
 Basic compatibility with RabbitMQ clients is already functional, and more protocol features are being added incrementally. See [ROADMAP.md](ROADMAP.md) for detailed development plans.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,25 +32,23 @@ OtterMQ aims to be a fully AMQP 0.9.1 compliant message broker with RabbitMQ com
   - [x] `BASIC_GET` for pull-based consumption
   - [x] Message count reporting
 
-### 🚧 **In Progress**
+### � **Recently Completed**
 
-- [ ] Consumer management system refactoring
+- [x] Consumer management system refactoring
+- [x] **`BASIC_CONSUME`** - Start consuming messages from queue
+  - [x] Consumer tag generation and management
+  - [x] Consumer registration per channel
+  - [x] Integration with queue message delivery
+- [x] **`BASIC_DELIVER`** - Server-initiated message delivery
+  - [x] Push-based message delivery to consumers
+  - [x] Delivery tag generation and tracking
+- [x] **`BASIC_CANCEL`** - Cancel consumer subscription
+  - [x] Clean consumer shutdown
+  - [x] Resource cleanup on cancellation
+- [x] **`BASIC_CONSUME_OK`** / **`BASIC_CANCEL_OK`** - Response frames
 
 ### ❌ **Missing Critical Features**
 
-#### **Phase 1: Message Consumption (High Priority)**
-
-- [ ] **`BASIC_CONSUME`** - Start consuming messages from queue
-  - [ ] Consumer tag generation and management
-  - [ ] Consumer registration per channel
-  - [ ] Integration with queue message delivery
-- [ ] **`BASIC_DELIVER`** - Server-initiated message delivery
-  - [ ] Push-based message delivery to consumers
-  - [ ] Delivery tag generation and tracking
-- [ ] **`BASIC_CANCEL`** - Cancel consumer subscription
-  - [ ] Clean consumer shutdown
-  - [ ] Resource cleanup on cancellation
-- [ ] **`BASIC_CONSUME_OK`** / **`BASIC_CANCEL_OK`** - Response frames
 
 #### **Phase 2: Message Acknowledgments (High Priority)**
 
@@ -229,7 +227,7 @@ The highest priority is **Phase 1: Core Messaging**. Contributors should focus o
 ## Progress Tracking
 
 **Last Updated**: October 2025  
-**Current Focus**: Phase 1 - Consumer Management  
-**Next Milestone**: Working `BASIC_CONSUME` implementation
+**Current Focus**: Phase 2 - Reliable Delivery (Message Acknowledgments)  
+**Next Milestone**: `BASIC_ACK` and delivery tracking implementation
 
 For detailed implementation tasks, see GitHub Issues tagged with the respective phase labels.

--- a/internal/core/amqp/basic.go
+++ b/internal/core/amqp/basic.go
@@ -20,7 +20,7 @@ type BasicConsumeContent struct {
 
 type BasicCancelContent struct {
 	ConsumerTag string
-	Nowait      bool
+	NoWait      bool
 }
 
 type BasicPublishContent struct {
@@ -452,7 +452,7 @@ func parseBasicCancelFrame(payload []byte) (*RequestMethodMessage, error) {
 
 	content := &BasicCancelContent{
 		ConsumerTag: consumerTag,
-		Nowait:      nowait,
+		NoWait:      nowait,
 	}
 	request := &RequestMethodMessage{
 		Content: content,

--- a/internal/core/amqp/basic.go
+++ b/internal/core/amqp/basic.go
@@ -83,6 +83,23 @@ func createBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string
 	return frame
 }
 
+func createBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
+	keyValuePairs := []KeyValue{
+		{
+			Key:   STRING_SHORT,
+			Value: consumerTag,
+		},
+	}
+
+	frame := ResponseMethodMessage{
+		Channel:  channel,
+		ClassID:  uint16(BASIC),
+		MethodID: uint16(BASIC_CANCEL_OK),
+		Content:  ContentList{KeyValuePairs: keyValuePairs},
+	}.FormatMethodFrame()
+	return frame
+}
+
 // createBasicDeliverFrame creates a Basic.Deliver (60) frame for the given message and delivery tag.
 func createBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte {
 	consumerTagKv := KeyValue{

--- a/internal/core/amqp/basic.go
+++ b/internal/core/amqp/basic.go
@@ -66,7 +66,7 @@ type BasicProperties struct {
 	Reserved        string         // shortstr
 }
 
-func createBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte {
+func createBasicConsumeOkFrame(channel uint16, consumerTag string) []byte {
 	keyValuePairs := []KeyValue{
 		{
 			Key:   STRING_SHORT,
@@ -75,8 +75,8 @@ func createBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string
 	}
 
 	frame := ResponseMethodMessage{
-		Channel:  request.Channel,
-		ClassID:  request.ClassID,
+		Channel:  channel,
+		ClassID:  uint16(BASIC),
 		MethodID: uint16(BASIC_CONSUME_OK),
 		Content:  ContentList{KeyValuePairs: keyValuePairs},
 	}.FormatMethodFrame()
@@ -134,22 +134,22 @@ func createBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey s
 	return frame
 }
 
-func createBasicGetEmptyFrame(request *RequestMethodMessage) []byte {
+func createBasicGetEmptyFrame(channel uint16) []byte {
 	// Send Basic.GetEmpty
 	reserved1 := KeyValue{
 		Key:   STRING_SHORT,
 		Value: "",
 	}
 	frame := ResponseMethodMessage{
-		Channel:  request.Channel,
-		ClassID:  request.ClassID,
+		Channel:  channel,
+		ClassID:  uint16(BASIC),
 		MethodID: uint16(BASIC_GET_EMPTY),
 		Content:  ContentList{KeyValuePairs: []KeyValue{reserved1}},
 	}.FormatMethodFrame()
 	return frame
 }
 
-func createBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte {
+func createBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte {
 	msgGetOk := &BasicGetOkContent{
 		DeliveryTag:  1,
 		Redelivered:  false,
@@ -159,8 +159,8 @@ func createBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey s
 	}
 
 	frame := ResponseMethodMessage{
-		Channel:  request.Channel,
-		ClassID:  request.ClassID,
+		Channel:  channel,
+		ClassID:  uint16(BASIC),
 		MethodID: uint16(BASIC_GET_OK),
 		Content:  *EncodeGetOkToContentList(msgGetOk),
 	}.FormatMethodFrame()

--- a/internal/core/amqp/basic.go
+++ b/internal/core/amqp/basic.go
@@ -44,7 +44,7 @@ type BasicGetOkContent struct {
 	MessageCount uint32
 }
 
-type BasicAckMessageContent struct {
+type BasicAckContent struct {
 	DeliveryTag uint64
 	Multiple    bool
 }
@@ -571,7 +571,7 @@ func parseBasicAckFrame(payload []byte) (*RequestMethodMessage, error) {
 	}
 	flags := DecodeFlags(octet, []string{"multiple"}, true)
 	multiple := flags["multiple"]
-	content := &BasicAckMessageContent{
+	content := &BasicAckContent{
 		DeliveryTag: deliveryTag,
 		Multiple:    multiple,
 	}

--- a/internal/core/amqp/basic_test.go
+++ b/internal/core/amqp/basic_test.go
@@ -707,7 +707,7 @@ func TestParseBasicCancelFrame_ValidPayload(t *testing.T) {
 		t.Errorf("Expected consumer tag 'test-consumer', got '%s'", content.ConsumerTag)
 	}
 
-	if content.Nowait {
+	if content.NoWait {
 		t.Error("Expected Nowait to be false")
 	}
 }
@@ -743,7 +743,7 @@ func TestParseBasicCancelFrame_WithNowaitFlag(t *testing.T) {
 		t.Errorf("Expected consumer tag 'consumer1', got '%s'", content.ConsumerTag)
 	}
 
-	if !content.Nowait {
+	if !content.NoWait {
 		t.Error("Expected Nowait to be true")
 	}
 }
@@ -799,7 +799,7 @@ func TestParseBasicCancelFrame_LongConsumerTag(t *testing.T) {
 		t.Errorf("Expected consumer tag length %d, got %d", len(consumerTag), len(content.ConsumerTag))
 	}
 
-	if !content.Nowait {
+	if !content.NoWait {
 		t.Error("Expected Nowait to be true")
 	}
 }
@@ -858,7 +858,7 @@ func TestParseBasicCancelFrame_SingleCharacterTag(t *testing.T) {
 		t.Errorf("Expected consumer tag 'x', got '%s'", content.ConsumerTag)
 	}
 
-	if content.Nowait {
+	if content.NoWait {
 		t.Error("Expected Nowait to be false")
 	}
 }

--- a/internal/core/amqp/basic_test.go
+++ b/internal/core/amqp/basic_test.go
@@ -676,4 +676,189 @@ func TestCreateBasicDeliverFrame_EdgeCases(t *testing.T) {
 	}
 }
 
-// Helper functions for min/max (if not available in your Go version)
+func TestParseBasicCancelFrame_ValidPayload(t *testing.T) {
+	// Create a payload with consumer tag "test-consumer" and nowait=false
+	var payload []byte
+
+	// Consumer tag: "test-consumer" (12 bytes + 1 length byte)
+	consumerTag := "test-consumer"
+	payload = append(payload, byte(len(consumerTag)))
+	payload = append(payload, []byte(consumerTag)...)
+
+	// Flags: nowait=false (bit 0 = 0)
+	payload = append(payload, 0x00)
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+
+	content, ok := result.Content.(*BasicCancelContent)
+	if !ok {
+		t.Fatalf("Expected BasicCancelContent, got %T", result.Content)
+	}
+
+	if content.ConsumerTag != "test-consumer" {
+		t.Errorf("Expected consumer tag 'test-consumer', got '%s'", content.ConsumerTag)
+	}
+
+	if content.Nowait {
+		t.Error("Expected Nowait to be false")
+	}
+}
+
+func TestParseBasicCancelFrame_WithNowaitFlag(t *testing.T) {
+	// Create a payload with consumer tag "consumer1" and nowait=true
+	var payload []byte
+
+	// Consumer tag: "consumer1"
+	consumerTag := "consumer1"
+	payload = append(payload, byte(len(consumerTag)))
+	payload = append(payload, []byte(consumerTag)...)
+
+	// Flags: nowait=true (bit 0 = 1)
+	payload = append(payload, 0x01)
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+
+	content, ok := result.Content.(*BasicCancelContent)
+	if !ok {
+		t.Fatalf("Expected BasicCancelContent, got %T", result.Content)
+	}
+
+	if content.ConsumerTag != "consumer1" {
+		t.Errorf("Expected consumer tag 'consumer1', got '%s'", content.ConsumerTag)
+	}
+
+	if !content.Nowait {
+		t.Error("Expected Nowait to be true")
+	}
+}
+
+func TestParseBasicCancelFrame_PayloadTooShort(t *testing.T) {
+	// Payload with only 2 bytes (minimum is 3)
+	payload := []byte{0x01, 0x41} // length=1, 'A'
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err == nil {
+		t.Error("Expected error for payload too short")
+	}
+
+	expectedError := "payload too short"
+	if err.Error() != expectedError {
+		t.Errorf("Expected error '%s', got '%s'", expectedError, err.Error())
+	}
+
+	if result != nil {
+		t.Error("Expected nil result")
+	}
+}
+
+func TestParseBasicCancelFrame_LongConsumerTag(t *testing.T) {
+	// Create payload with long consumer tag (255 chars - maximum for short string)
+	consumerTag := string(make([]byte, 255))
+	for i := range consumerTag {
+		consumerTag = consumerTag[:i] + "a" + consumerTag[i+1:]
+	}
+
+	var payload []byte
+	payload = append(payload, byte(len(consumerTag)))
+	payload = append(payload, []byte(consumerTag)...)
+	payload = append(payload, 0x01) // nowait=true
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+
+	content, ok := result.Content.(*BasicCancelContent)
+	if !ok {
+		t.Fatalf("Expected BasicCancelContent, got %T", result.Content)
+	}
+
+	if content.ConsumerTag != consumerTag {
+		t.Errorf("Expected consumer tag length %d, got %d", len(consumerTag), len(content.ConsumerTag))
+	}
+
+	if !content.Nowait {
+		t.Error("Expected Nowait to be true")
+	}
+}
+
+func TestParseBasicCancelFrame_MissingFlagsByte(t *testing.T) {
+	// Create payload missing the flags byte
+	var payload []byte
+
+	// Consumer tag: "test"
+	consumerTag := "test"
+	payload = append(payload, byte(len(consumerTag)))
+	payload = append(payload, []byte(consumerTag)...)
+	// Missing flags byte
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err == nil {
+		t.Error("Expected error for missing flags byte")
+	}
+
+	if !bytes.Contains([]byte(err.Error()), []byte("failed to read octet")) {
+		t.Errorf("Expected error about reading octet, got: %v", err)
+	}
+
+	if result != nil {
+		t.Error("Expected nil result")
+	}
+}
+
+func TestParseBasicCancelFrame_SingleCharacterTag(t *testing.T) {
+	// Test with minimum valid consumer tag (1 character)
+	var payload []byte
+
+	// Consumer tag: "x"
+	consumerTag := "x"
+	payload = append(payload, byte(len(consumerTag)))
+	payload = append(payload, []byte(consumerTag)...)
+	payload = append(payload, 0x00) // nowait=false
+
+	result, err := parseBasicCancelFrame(payload)
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+
+	content, ok := result.Content.(*BasicCancelContent)
+	if !ok {
+		t.Fatalf("Expected BasicCancelContent, got %T", result.Content)
+	}
+
+	if content.ConsumerTag != "x" {
+		t.Errorf("Expected consumer tag 'x', got '%s'", content.ConsumerTag)
+	}
+
+	if content.Nowait {
+		t.Error("Expected Nowait to be false")
+	}
+}

--- a/internal/core/amqp/framer.go
+++ b/internal/core/amqp/framer.go
@@ -15,11 +15,10 @@ type Framer interface {
 
 	// Basic Methods
 	CreateBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte
-	CreateBasicGetEmptyFrame(request *RequestMethodMessage) []byte
-	CreateBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte
-	CreateBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte
+	CreateBasicGetEmptyFrame(channel uint16) []byte
+	CreateBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte
+	CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte
 	CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte
-
 
 	// Queue Methods
 	CreateQueueDeclareOkFrame(request *RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte
@@ -104,16 +103,20 @@ func (d *DefaultFramer) CreateBasicDeliverFrame(channel uint16, consumerTag, exc
 	return createBasicDeliverFrame(channel, consumerTag, exchange, routingKey, deliveryTag, redelivered)
 }
 
-func (d *DefaultFramer) CreateBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte {
-	return createBasicConsumeOkFrame(request, consumerTag)
+func (d *DefaultFramer) CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte {
+	return createBasicConsumeOkFrame(channel, consumerTag)
 }
 
-func (d *DefaultFramer) CreateBasicGetEmptyFrame(request *RequestMethodMessage) []byte {
-	return createBasicGetEmptyFrame(request)
+func (d *DefaultFramer) CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
+	return createBasicCancelOkFrame(channel, consumerTag)
 }
 
-func (d *DefaultFramer) CreateBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte {
-	return createBasicGetOkFrame(request, exchange, routingkey, msgCount)
+func (d *DefaultFramer) CreateBasicGetEmptyFrame(channel uint16) []byte {
+	return createBasicGetEmptyFrame(channel)
+}
+
+func (d *DefaultFramer) CreateBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte {
+	return createBasicGetOkFrame(channel, exchange, routingkey, msgCount)
 }
 
 func (d *DefaultFramer) CreateCloseFrame(channel, replyCode, classID, methodID, closeClassID, closeClassMethod uint16, replyText string) []byte {

--- a/internal/core/amqp/framer.go
+++ b/internal/core/amqp/framer.go
@@ -18,6 +18,8 @@ type Framer interface {
 	CreateBasicGetEmptyFrame(request *RequestMethodMessage) []byte
 	CreateBasicGetOkFrame(request *RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte
 	CreateBasicConsumeOkFrame(request *RequestMethodMessage, consumerTag string) []byte
+	CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte
+
 
 	// Queue Methods
 	CreateQueueDeclareOkFrame(request *RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte

--- a/internal/core/amqp/parsers.go
+++ b/internal/core/amqp/parsers.go
@@ -185,7 +185,7 @@ func parseHeaderFrame(channel uint16, payloadSize uint32, payload []byte) (*Chan
 	switch classID {
 
 	case uint16(BASIC):
-		log.Debug().Uint16("channel", channel).Msg("Received BASIC HEADER frame")
+		log.Trace().Uint16("channel", channel).Msg("Received BASIC HEADER frame")
 		request, err := parseBasicHeader(payload)
 		if err != nil {
 			return nil, err

--- a/internal/core/amqp/parsers.go
+++ b/internal/core/amqp/parsers.go
@@ -140,6 +140,17 @@ func parseMethodFrame(channel uint16, payload []byte) (*ChannelState, error) {
 		log.Debug().Uint16("channel", channel).Msg("Received BASIC frame")
 		request, err := parseBasicMethod(methodID, methodPayload)
 		if err != nil {
+			// The raised exception (connection type):
+			// (501 - "frame error"),
+			// (502 - "syntax error"),
+			// (503 - "command invalid"),
+			// (504 - "channel error"), -- shall be handled at a higher level
+			// (505 - "unexpected frame"),
+			// (506 - "resource error"), -- shall be handled at a higher level
+			// (530 - "not allowed"), -- shall be handled at a higher level
+			// (540 - "not implemented"),
+			// (541 - "internal error"),
+			//
 			return nil, err
 		}
 		if request != nil {

--- a/internal/core/broker/basic.go
+++ b/internal/core/broker/basic.go
@@ -65,7 +65,7 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 
 		}
 	case uint16(amqp.BASIC_GET):
-		getMsg := request.Content.(*amqp.BasicGetMessage)
+		getMsg := request.Content.(*amqp.BasicGetMessageContent)
 		queue := getMsg.Queue
 		msgCount, err := vh.GetMessageCount(queue)
 		if err != nil {

--- a/internal/core/broker/basic.go
+++ b/internal/core/broker/basic.go
@@ -74,7 +74,7 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 			return nil, err
 		}
 		if msgCount == 0 {
-			frame := b.framer.CreateBasicGetEmptyFrame(request)
+			frame := b.framer.CreateBasicGetEmptyFrame(request.Channel)
 			if err := b.framer.SendFrame(conn, frame); err != nil {
 				log.Error().Err(err).Msg("Failed to send basic get empty frame")
 			}
@@ -84,7 +84,7 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 		// Send Basic.GetOk + header + body
 		msg := vh.GetMessage(queue)
 
-		frame := b.framer.CreateBasicGetOkFrame(request, msg.Exchange, msg.RoutingKey, uint32(msgCount))
+		frame := b.framer.CreateBasicGetOkFrame(request.Channel, msg.Exchange, msg.RoutingKey, uint32(msgCount))
 		err = b.framer.SendFrame(conn, frame)
 		log.Debug().Str("queue", queue).Str("id", msg.ID).Msg("Sent message from queue")
 
@@ -181,7 +181,7 @@ func (b *Broker) basicConsumeHandler(request *amqp.RequestMethodMessage, conn ne
 	}
 
 	if !noWait {
-		frame := b.framer.CreateBasicConsumeOkFrame(request, consumerTag)
+		frame := b.framer.CreateBasicConsumeOkFrame(request.Channel, consumerTag)
 		if err := b.framer.SendFrame(conn, frame); err != nil {
 			log.Error().Err(err).Msg("Failed to send basic consume ok frame")
 			// Verify if should return error (as channel exception) or just log it

--- a/internal/core/broker/basic.go
+++ b/internal/core/broker/basic.go
@@ -35,7 +35,7 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 		if currentState.HeaderFrame == nil && newState.HeaderFrame != nil {
 			b.Connections[conn].Channels[channel].HeaderFrame = newState.HeaderFrame
 			b.Connections[conn].Channels[channel].BodySize = newState.HeaderFrame.BodySize
-			log.Debug().Interface("state", b.getCurrentState(conn, channel)).Msg("Current state after update header")
+			log.Trace().Interface("state", b.getCurrentState(conn, channel)).Msg("Current state after update header")
 			return nil, nil
 		}
 		if currentState.Body == nil && newState.Body != nil {
@@ -45,9 +45,9 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 		}
 		log.Trace().Interface("state", currentState).Msg("Current state after all")
 		if currentState.MethodFrame.Content != nil && currentState.HeaderFrame != nil && currentState.BodySize > 0 && currentState.Body != nil {
-			log.Debug().Interface("state", currentState).Msg("All fields must be filled")
+			log.Trace().Interface("state", currentState).Msg("All fields must be filled")
 			if len(currentState.Body) != int(currentState.BodySize) {
-				log.Debug().Int("body_len", len(currentState.Body)).Uint64("expected", currentState.BodySize).Msg("Body size is not correct")
+				log.Trace().Int("body_len", len(currentState.Body)).Uint64("expected", currentState.BodySize).Msg("Body size is not correct")
 				// TODO: handle this error properly, maybe sending the correct channel exception
 				// vide amqp.constants.go Exceptions
 				return nil, fmt.Errorf("body size is not correct: %d != %d", len(currentState.Body), currentState.BodySize)
@@ -59,7 +59,7 @@ func (b *Broker) basicHandler(newState *amqp.ChannelState, vh *vhost.VHost, conn
 			props := currentState.HeaderFrame.Properties
 			_, err := vh.Publish(exchanege, routingKey, body, props)
 			if err == nil {
-				log.Debug().Str("exchange", exchanege).Str("routing_key", routingKey).Str("body", string(body)).Msg("Published message")
+				log.Trace().Str("exchange", exchanege).Str("routing_key", routingKey).Str("body", string(body)).Msg("Published message")
 				b.Connections[conn].Channels[channel] = &amqp.ChannelState{}
 			}
 			return nil, err

--- a/internal/core/broker/basic_test.go
+++ b/internal/core/broker/basic_test.go
@@ -60,13 +60,13 @@ func (m *MockFramer) CreateBodyFrame(channel uint16, content []byte) []byte {
 func (m *MockFramer) CreateBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte {
 	return []byte("basic-deliver")
 }
-func (m *MockFramer) CreateBasicGetEmptyFrame(request *amqp.RequestMethodMessage) []byte {
+func (m *MockFramer) CreateBasicGetEmptyFrame(channel uint16) []byte {
 	return []byte("basic-get-empty")
 }
-func (m *MockFramer) CreateBasicGetOkFrame(request *amqp.RequestMethodMessage, exchange, routingkey string, msgCount uint32) []byte {
+func (m *MockFramer) CreateBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte {
 	return []byte("basic-get-ok")
 }
-func (m *MockFramer) CreateBasicConsumeOkFrame(request *amqp.RequestMethodMessage, consumerTag string) []byte {
+func (m *MockFramer) CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte {
 	return []byte("basic-consume-ok:" + consumerTag)
 }
 func (m *MockFramer) CreateQueueDeclareOkFrame(request *amqp.RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte {

--- a/internal/core/broker/basic_test.go
+++ b/internal/core/broker/basic_test.go
@@ -69,6 +69,9 @@ func (m *MockFramer) CreateBasicGetOkFrame(channel uint16, exchange, routingkey 
 func (m *MockFramer) CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte {
 	return []byte("basic-consume-ok:" + consumerTag)
 }
+func (m *MockFramer) CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
+	return []byte("basic-cancel-ok:" + consumerTag)
+}
 func (m *MockFramer) CreateQueueDeclareOkFrame(request *amqp.RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte {
 	return []byte("queue-declare")
 }

--- a/internal/core/broker/connection.go
+++ b/internal/core/broker/connection.go
@@ -74,15 +74,15 @@ func (b *Broker) handleConnection(conn net.Conn, connInfo *amqp.ConnectionInfo) 
 			}
 		} else {
 			if newState.HeaderFrame != nil {
-				log.Debug().Interface("header", newState.HeaderFrame).Msg("HeaderFrame")
+				log.Trace().Interface("header", newState.HeaderFrame).Msg("HeaderFrame")
 			} else if newState.Body != nil {
-				log.Debug().Interface("body", newState.Body).Msg("Body")
+				log.Trace().Interface("body", newState.Body).Msg("Body")
 			}
 			if previousState, exists := b.Connections[conn].Channels[channelNum]; exists {
 				newState.MethodFrame = previousState.MethodFrame
-				log.Debug().Interface("method_frame", previousState.MethodFrame).Msg("Recovered method frame")
+				log.Trace().Interface("method_frame", previousState.MethodFrame).Msg("Recovered method frame")
 			} else {
-				log.Debug().Uint16("channel", channelNum).Msg("Channel not found")
+				log.Trace().Uint16("channel", channelNum).Msg("Channel not found")
 				continue
 			}
 		}

--- a/internal/core/broker/public.go
+++ b/internal/core/broker/public.go
@@ -118,12 +118,14 @@ func (a DefaultManagerApi) ListQueues() ([]models.QueueDTO, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, vh := range b.VHosts {
+		unacked := vh.GetUnackedMessageCountsAllQueues()
 		for _, queue := range vh.Queues {
 			queues = append(queues, models.QueueDTO{
 				VHostName: vh.Name,
 				VHostId:   vh.Id,
 				Name:      queue.Name,
 				Messages:  queue.Len(),
+				Unacked:   unacked[queue.Name],
 			})
 		}
 	}

--- a/internal/core/broker/vhost/ack.go
+++ b/internal/core/broker/vhost/ack.go
@@ -1,0 +1,32 @@
+package vhost
+
+import (
+	"fmt"
+	"net"
+)
+
+func (vh *VHost) HandleBasicAck(conn net.Conn, channel uint16, deliveryTag uint64, multiple bool) error {
+	key := ConnectionChannelKey{conn, channel}
+
+	vh.mu.Lock()
+	ch := vh.ChannelDeliveries[key]
+	vh.mu.Unlock()
+	if ch == nil {
+		return fmt.Errorf("no channel delivery state for channel %d", channel)
+	}
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	if multiple {
+		for tag := range ch.Unacked {
+			if tag <= deliveryTag {
+				delete(ch.Unacked, tag)
+			}
+		}
+	} else {
+		delete(ch.Unacked, deliveryTag)
+	}
+
+	return nil
+}

--- a/internal/core/broker/vhost/ack_test.go
+++ b/internal/core/broker/vhost/ack_test.go
@@ -1,0 +1,185 @@
+package vhost
+
+import (
+	"net"
+	"testing"
+
+	"github.com/andrelcunha/ottermq/internal/core/amqp"
+)
+
+// helper to build a minimal consumer
+func newTestConsumer(conn net.Conn, ch uint16, queue string, noAck bool) *Consumer {
+	return &Consumer{
+		Tag:        "ctag-test",
+		Channel:    ch,
+		QueueName:  queue,
+		Connection: conn,
+		Active:     true,
+		Props: &ConsumerProperties{
+			NoAck: noAck,
+		},
+	}
+}
+
+func TestChannelDeliveryState_SingleAck(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+
+	// Fake connection (nil is sufficient for HandleBasicAck)
+	var conn net.Conn = nil
+
+	// Register consumer (manual ack)
+	c := newTestConsumer(conn, 1, "q1", false)
+
+	// Manually simulate two deliveries by recording unacked entries
+	key := ConnectionChannelKey{conn, c.Channel}
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+	vh.mu.Lock()
+	vh.ChannelDeliveries[key] = ch
+	vh.mu.Unlock()
+
+	// Simulate two delivered messages (manual ack)
+	m1 := amqp.Message{ID: "m1", Body: []byte("m1")}
+	m2 := amqp.Message{ID: "m2", Body: []byte("m2")}
+
+	ch.mu.Lock()
+	ch.LastDeliveryTag++
+	t1 := ch.LastDeliveryTag
+	ch.Unacked[t1] = &DeliveryRecord{DeliveryTag: t1, ConsumerTag: c.Tag, QueueName: c.QueueName, Message: m1}
+
+	ch.LastDeliveryTag++
+	t2 := ch.LastDeliveryTag
+	ch.Unacked[t2] = &DeliveryRecord{DeliveryTag: t2, ConsumerTag: c.Tag, QueueName: c.QueueName, Message: m2}
+	ch.mu.Unlock()
+
+	if len(ch.Unacked) != 2 {
+		t.Fatalf("expected 2 unacked, got %d", len(ch.Unacked))
+	}
+
+	// Ack first only (single)
+	if err := vh.HandleBasicAck(conn, c.Channel, t1, false); err != nil {
+		t.Fatalf("HandleBasicAck error: %v", err)
+	}
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+	if _, ok := ch.Unacked[t1]; ok {
+		t.Fatalf("delivery tag %d should be removed after ack", t1)
+	}
+	if _, ok := ch.Unacked[t2]; !ok {
+		t.Fatalf("delivery tag %d should remain unacked", t2)
+	}
+}
+
+func TestChannelDeliveryState_MultipleAck(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	var conn net.Conn = nil
+	key := ConnectionChannelKey{conn, 1}
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+
+	vh.mu.Lock()
+	vh.ChannelDeliveries[key] = ch
+	vh.mu.Unlock()
+
+	// create 3 tags
+	ch.mu.Lock()
+	for i := 0; i < 3; i++ {
+		ch.LastDeliveryTag++
+		tag := ch.LastDeliveryTag
+		ch.Unacked[tag] = &DeliveryRecord{DeliveryTag: tag}
+	}
+	ch.mu.Unlock()
+
+	if len(ch.Unacked) != 3 {
+		t.Fatalf("expected 3 unacked, got %d", len(ch.Unacked))
+	}
+
+	// multiple ack up to second tag
+	upTo := uint64(2)
+	if err := vh.HandleBasicAck(conn, 1, upTo, true); err != nil {
+		t.Fatalf("HandleBasicAck error: %v", err)
+	}
+
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+	if len(ch.Unacked) != 1 {
+		t.Fatalf("expected 1 unacked remaining, got %d", len(ch.Unacked))
+	}
+	if _, ok := ch.Unacked[3]; !ok {
+		t.Fatalf("expected tag 3 to remain")
+	}
+}
+
+func TestChannelDeliveryState_UnknownTag(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	var conn net.Conn = nil
+	// Ack when there is no state — should return error in current implementation
+	if err := vh.HandleBasicAck(conn, 1, 42, false); err == nil {
+		t.Fatalf("expected error when channel delivery state is missing")
+	}
+}
+
+func TestDeliverTracking_NoAckFlag(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	var conn net.Conn = nil
+	key := ConnectionChannelKey{conn, 2}
+
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+	vh.mu.Lock()
+	vh.ChannelDeliveries[key] = ch
+	vh.mu.Unlock()
+
+	// Simulate manual-ack delivery — stored
+	ch.mu.Lock()
+	ch.LastDeliveryTag++
+	tag1 := ch.LastDeliveryTag
+	ch.Unacked[tag1] = &DeliveryRecord{DeliveryTag: tag1}
+	ch.mu.Unlock()
+
+	// Simulate auto-ack delivery — not stored
+	ch.mu.Lock()
+	ch.LastDeliveryTag++
+	// intentionally do NOT store second tag to simulate NoAck=true
+	ch.mu.Unlock()
+
+	if len(ch.Unacked) != 1 {
+		t.Fatalf("expected only 1 unacked stored (manual ack), got %d", len(ch.Unacked))
+	}
+}
+
+func TestCleanupChannel_RequeuesUnacked(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	// Create a queue
+	q, err := vh.CreateQueue("q-clean", nil)
+	if err != nil {
+		t.Fatalf("CreateQueue error: %v", err)
+	}
+
+	// Prepare an unacked record on channel (conn=nil, ch=3)
+	var conn net.Conn = nil
+	key := ConnectionChannelKey{conn, 3}
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+	vh.mu.Lock()
+	vh.ChannelDeliveries[key] = ch
+	vh.mu.Unlock()
+
+	msg := amqp.Message{ID: "mx", Body: []byte("x")}
+	ch.mu.Lock()
+	ch.LastDeliveryTag = 1
+	ch.Unacked[1] = &DeliveryRecord{DeliveryTag: 1, QueueName: q.Name, Message: msg}
+	ch.mu.Unlock()
+
+	// Cleanup should requeue the unacked message into q
+	vh.CleanupChannel(conn, 3)
+
+	if got := q.Len(); got != 1 {
+		t.Fatalf("expected queue length 1 after requeue, got %d", got)
+	}
+
+	// ChannelDeliveries entry should be removed
+	vh.mu.Lock()
+	_, exists := vh.ChannelDeliveries[key]
+	vh.mu.Unlock()
+	if exists {
+		t.Fatalf("expected ChannelDeliveries entry to be removed after cleanup")
+	}
+}

--- a/internal/core/broker/vhost/consumer.go
+++ b/internal/core/broker/vhost/consumer.go
@@ -21,13 +21,15 @@ type ConnectionChannelKey struct {
 }
 
 type Consumer struct {
-	Tag         string
-	Channel     uint16
-	QueueName   string
-	Connection  net.Conn
-	DeliveryTag uint64 // will be incremented per delivery
-	Active      bool
-	Props       *ConsumerProperties
+	Tag             string
+	Channel         uint16
+	QueueName       string
+	Connection      net.Conn
+	DeliveryTag     uint64 // will be incremented per delivery
+	Active          bool
+	Props           *ConsumerProperties
+	UnackedMessages map[uint64]*amqp.Message // deliveryTag -> message
+	LastDeliveryTag uint64
 }
 
 type ConsumerProperties struct {

--- a/internal/core/broker/vhost/consumer.go
+++ b/internal/core/broker/vhost/consumer.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-
-	"github.com/andrelcunha/ottermq/internal/core/amqp"
-	"github.com/rs/zerolog/log"
 )
 
 type ConsumerKey struct {
@@ -21,15 +18,12 @@ type ConnectionChannelKey struct {
 }
 
 type Consumer struct {
-	Tag             string
-	Channel         uint16
-	QueueName       string
-	Connection      net.Conn
-	DeliveryTag     uint64 // will be incremented per delivery
-	Active          bool
-	Props           *ConsumerProperties
-	UnackedMessages map[uint64]*amqp.Message // deliveryTag -> message
-	LastDeliveryTag uint64
+	Tag        string
+	Channel    uint16
+	QueueName  string
+	Connection net.Conn
+	Active     bool
+	Props      *ConsumerProperties
 }
 
 type ConsumerProperties struct {
@@ -174,9 +168,32 @@ func (vh *VHost) CleanupChannel(connection net.Conn, channel uint16) {
 
 	channelKey := ConnectionChannelKey{connection, channel}
 	// Get copy of consumers to avoid modification during iteration
+	_ = cancelAllConsumers(vh, channelKey)
+
+	if ch := vh.ChannelDeliveries[channelKey]; ch != nil {
+		ch.mu.Lock()
+		// copy records to avoid modification during iteration
+		records := make([]*DeliveryRecord, 0, len(ch.Unacked))
+		for _, record := range ch.Unacked {
+			records = append(records, record)
+		}
+		ch.mu.Unlock()
+
+		// Requeue unacknowledged messages
+		for _, record := range records {
+			queue, exists := vh.Queues[record.QueueName]
+			if exists {
+				queue.Push(record.Message)
+			}
+		}
+		delete(vh.ChannelDeliveries, channelKey)
+	}
+}
+
+func cancelAllConsumers(vh *VHost, channelKey ConnectionChannelKey) bool {
 	consumersForChannel, exists := vh.ConsumersByChannel[channelKey]
 	if !exists {
-		return // No consumers on this channel
+		return true // No consumers on this channel
 	}
 
 	consumersCopy := make([]*Consumer, len(consumersForChannel))
@@ -190,6 +207,7 @@ func (vh *VHost) CleanupChannel(connection net.Conn, channel uint16) {
 		vh.mu.Lock()
 	}
 	delete(vh.ConsumersByChannel, channelKey)
+	return false
 }
 
 func (vh *VHost) CleanupConnection(connection net.Conn) {
@@ -228,45 +246,6 @@ func (vh *VHost) GetActiveConsumersForQueue(queueName string) []*Consumer {
 		}
 	}
 	return activeConsumers
-}
-
-func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message) error {
-	// vh should not have access to framer
-	// nevertheless, i don't know how to get the framer without a circular dependency
-	if !consumer.Active {
-		return fmt.Errorf("consumer %s on channel %d is not active", consumer.Tag, consumer.Channel)
-	}
-	consumer.DeliveryTag++
-	deliverFrame := vh.framer.CreateBasicDeliverFrame(
-		consumer.Channel,
-		consumer.Tag,
-		msg.Exchange,
-		msg.RoutingKey,
-		consumer.DeliveryTag,
-		false, // redelivered - TODO: implement redelivery logic
-	)
-
-	headerFrame := vh.framer.CreateHeaderFrame(consumer.Channel, uint16(amqp.BASIC), msg)
-
-	bodyFrame := vh.framer.CreateBodyFrame(consumer.Channel, msg.Body)
-
-	if err := vh.framer.SendFrame(consumer.Connection, deliverFrame); err != nil {
-		log.Error().Err(err).Msg("Failed to send deliver frame")
-		return err
-	}
-	if err := vh.framer.SendFrame(consumer.Connection, headerFrame); err != nil {
-		log.Error().Err(err).Msg("Failed to send header frame")
-		return err
-	}
-	if err := vh.framer.SendFrame(consumer.Connection, bodyFrame); err != nil {
-		log.Error().Err(err).Msg("Failed to send body frame")
-		return err
-	}
-
-	// TODO: realize how to handle NoAck consumers and message acks
-	// For now, we assume all consumers are NoAck
-	// So we don't need to track unacknowledged messages
-	return nil
 }
 
 func generatePseudoRandomString(n int) string {

--- a/internal/core/broker/vhost/delivery.go
+++ b/internal/core/broker/vhost/delivery.go
@@ -1,0 +1,93 @@
+package vhost
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/andrelcunha/ottermq/internal/core/amqp"
+	"github.com/rs/zerolog/log"
+)
+
+type DeliveryRecord struct {
+	DeliveryTag uint64
+	ConsumerTag string
+	QueueName   string
+	Message     amqp.Message
+	Persistent  bool
+}
+
+type ChannelDeliveryState struct {
+	mu              sync.Mutex
+	LastDeliveryTag uint64
+	Unacked         map[uint64]*DeliveryRecord // deliveryTag -> DeliveryRecord
+}
+
+func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message) error {
+	if !consumer.Active {
+		return fmt.Errorf("consumer %s on channel %d is not active", consumer.Tag, consumer.Channel)
+	}
+	channelKey := ConnectionChannelKey{consumer.Connection, consumer.Channel}
+	vh.mu.Lock()
+	ch := vh.ChannelDeliveries[channelKey]
+	if ch == nil {
+		ch = &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+		vh.ChannelDeliveries[channelKey] = ch
+	}
+	vh.mu.Unlock()
+
+	ch.mu.Lock()
+	ch.LastDeliveryTag++
+	tag := ch.LastDeliveryTag
+
+	track := !consumer.Props.NoAck // only track when manual ack is required
+	if track {
+		ch.Unacked[tag] = &DeliveryRecord{
+			DeliveryTag: tag,
+			ConsumerTag: consumer.Tag,
+			QueueName:   consumer.QueueName,
+			Message:     msg,
+			Persistent:  msg.Properties.DeliveryMode == amqp.PERSISTENT,
+		}
+	}
+	ch.mu.Unlock()
+
+	deliverFrame := vh.framer.CreateBasicDeliverFrame(
+		consumer.Channel,
+		consumer.Tag,
+		msg.Exchange,
+		msg.RoutingKey,
+		tag,
+		false, // redelivered - TODO: implement redelivery logic
+	)
+	headerFrame := vh.framer.CreateHeaderFrame(consumer.Channel, uint16(amqp.BASIC), msg)
+	bodyFrame := vh.framer.CreateBodyFrame(consumer.Channel, msg.Body)
+
+	if err := vh.framer.SendFrame(consumer.Connection, deliverFrame); err != nil {
+		log.Error().Err(err).Msg("Failed to send deliver frame")
+		if track {
+			ch.mu.Lock()
+			delete(ch.Unacked, tag)
+			ch.mu.Unlock()
+		}
+		return err
+	}
+	if err := vh.framer.SendFrame(consumer.Connection, headerFrame); err != nil {
+		log.Error().Err(err).Msg("Failed to send header frame")
+		if track {
+			ch.mu.Lock()
+			delete(ch.Unacked, tag)
+			ch.mu.Unlock()
+		}
+		return err
+	}
+	if err := vh.framer.SendFrame(consumer.Connection, bodyFrame); err != nil {
+		log.Error().Err(err).Msg("Failed to send body frame")
+		if track {
+			ch.mu.Lock()
+			delete(ch.Unacked, tag)
+			ch.mu.Unlock()
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/core/broker/vhost/queue.go
+++ b/internal/core/broker/vhost/queue.go
@@ -58,7 +58,10 @@ func (q *Queue) startDeliveryLoop(vh *VHost) {
 				q.delivering = false
 				return
 			case msg := <-q.messages:
-				// Here we would deliver the message to consumers
+				q.mu.Lock()
+				q.count--
+				q.mu.Unlock()
+
 				log.Debug().Str("queue", q.Name).Str("id", msg.ID).Msg("Delivering message to consumers")
 				consumers := vh.GetActiveConsumersForQueue(q.Name)
 				if len(consumers) > 0 {

--- a/internal/core/broker/vhost/queue.go
+++ b/internal/core/broker/vhost/queue.go
@@ -74,6 +74,7 @@ func (q *Queue) startDeliveryLoop(vh *VHost) {
 						vh.CancelConsumer(consumer.Channel, consumer.Tag)
 						// Requeue the message
 						// Requeue just if rejected and `requeue` is true
+						q.Push(msg)
 					}
 				}
 			}
@@ -211,18 +212,6 @@ func (q *Queue) Pop() *amqp.Message {
 	default:
 		log.Debug().Str("queue", q.Name).Msg("Queue is empty")
 		return nil
-	}
-}
-
-func (q *Queue) ReQueue(msg amqp.Message) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	select {
-	case q.messages <- msg:
-		q.count++
-		log.Debug().Str("queue", q.Name).Str("id", msg.ID).Bytes("body", msg.Body).Msg("Pushed message to queue")
-	default:
-		log.Debug().Str("queue", q.Name).Str("id", msg.ID).Msg("Queue channel full, dropping message")
 	}
 }
 

--- a/internal/core/broker/vhost/vhost.go
+++ b/internal/core/broker/vhost/vhost.go
@@ -2,6 +2,7 @@ package vhost
 
 import (
 	"context"
+	"net"
 	"sync"
 
 	"github.com/andrelcunha/ottermq/internal/core/amqp"
@@ -22,10 +23,9 @@ type VHost struct {
 	Consumers          map[ConsumerKey]*Consumer            `json:"consumers"`          // <- Primary registry
 	ConsumersByQueue   map[string][]*Consumer               `json:"consumers_by_queue"` // <- Delivery Index
 	ConsumersByChannel map[ConnectionChannelKey][]*Consumer // Index consumers by connection+channel
-	/*Delivery*/
-	activeDeliveries  map[string]context.CancelFunc // queueName -> cancelFunc
-	framer            amqp.Framer
-	ChannelDeliveries map[ConnectionChannelKey]*ChannelDeliveryState
+	activeDeliveries   map[string]context.CancelFunc        // queueName -> cancelFunc
+	framer             amqp.Framer
+	ChannelDeliveries  map[ConnectionChannelKey]*ChannelDeliveryState
 }
 
 func NewVhost(vhostName string, queueBufferSize int, persist persistence.Persistence) *VHost {
@@ -54,4 +54,38 @@ func (vh *VHost) SetFramer(framer amqp.Framer) {
 
 func (vh *VHost) createMandatoryStructure() {
 	vh.createMandatoryExchanges()
+}
+
+// GetUnackedMessageCountsAllQueues returns a map of queue names to their respective counts of unacknowledged messages.
+func (vh *VHost) GetUnackedMessageCountsAllQueues() map[string]int {
+	vh.mu.Lock()
+	defer vh.mu.Unlock()
+
+	counts := make(map[string]int)
+	for _, channelState := range vh.ChannelDeliveries {
+		channelState.mu.Lock()
+		for _, record := range channelState.Unacked {
+			counts[record.QueueName]++
+		}
+		channelState.mu.Unlock()
+	}
+	return counts
+}
+
+// GetUnackedMessageCountByChannel returns the count of unacknowledged messages for a specific connection and channel.
+func (vh *VHost) GetUnackedMessageCountByChannel(conn net.Conn, channel uint16) int {
+	vh.mu.Lock()
+	defer vh.mu.Unlock()
+
+	key := ConnectionChannelKey{conn, channel}
+	channelState := vh.ChannelDeliveries[key]
+	if channelState == nil {
+		return 0
+	}
+
+	channelState.mu.Lock()
+	count := len(channelState.Unacked)
+	channelState.mu.Unlock()
+
+	return count
 }

--- a/internal/core/broker/vhost/vhost.go
+++ b/internal/core/broker/vhost/vhost.go
@@ -23,8 +23,9 @@ type VHost struct {
 	ConsumersByQueue   map[string][]*Consumer               `json:"consumers_by_queue"` // <- Delivery Index
 	ConsumersByChannel map[ConnectionChannelKey][]*Consumer // Index consumers by connection+channel
 	/*Delivery*/
-	activeDeliveries map[string]context.CancelFunc // queueName -> cancelFunc
-	framer           amqp.Framer
+	activeDeliveries  map[string]context.CancelFunc // queueName -> cancelFunc
+	framer            amqp.Framer
+	ChannelDeliveries map[ConnectionChannelKey]*ChannelDeliveryState
 }
 
 func NewVhost(vhostName string, queueBufferSize int, persist persistence.Persistence) *VHost {
@@ -41,6 +42,7 @@ func NewVhost(vhostName string, queueBufferSize int, persist persistence.Persist
 		ConsumersByQueue:   make(map[string][]*Consumer),
 		ConsumersByChannel: make(map[ConnectionChannelKey][]*Consumer),
 		activeDeliveries:   make(map[string]context.CancelFunc),
+		ChannelDeliveries:  make(map[ConnectionChannelKey]*ChannelDeliveryState),
 	}
 	vh.createMandatoryStructure()
 	return vh

--- a/internal/core/models/dto.go
+++ b/internal/core/models/dto.go
@@ -52,6 +52,7 @@ type QueueDTO struct {
 	VHostId   string `json:"vhost_id"`
 	Name      string `json:"name"`
 	Messages  int    `json:"messages"`
+	Unacked   int    `json:"unacked"`
 }
 
 type BindingDTO struct {

--- a/ottermq_ui/src/pages/QueuesPage.vue
+++ b/ottermq_ui/src/pages/QueuesPage.vue
@@ -72,7 +72,7 @@ const rows = computed(() =>
   store.items.map(q => ({
     ...q,
     status: 'running',
-    unacked: (q.messages_unacknowledged || 0),
+    unacked: (q.unacked || 0),
     persisted: (q.messages_persistent || 0),
     total: (q.messages || 0)
   }))


### PR DESCRIPTION
Enhance the message broker with BASIC_CANCEL and BASIC_ACK frame handling, including comprehensive tests and improved logging. Update the API to expose unacknowledged message counts and refine the documentation to reflect the completion of push-based message consumption features.