### PR TITLE
Add BASIC_REJECT frame handling and enhance persistence

### DIFF
--- a/internal/core/broker/state_recovery.go
+++ b/internal/core/broker/state_recovery.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/andrelcunha/ottermq/internal/core/broker/vhost"
+	"github.com/andrelcunha/ottermq/pkg/persistence"
 	"github.com/rs/zerolog/log"
 )
 
@@ -32,8 +33,14 @@ func RecoverBrokerState(b *Broker) error {
 			exchangeType, props, err := b.persist.LoadExchangeMetadata(vhostName, exName)
 
 			if err == nil {
+				bindings, err := b.persist.LoadExchangeBindings(vhostName, exName)
+				if err != nil {
+					log.Error().Err(err).Str("exchange", exName).Msg("Failed to load exchange bindings")
+					bindings = []persistence.BindingData{}
+				}
+
 				// Create exchange in vhost using persistedEx
-				v.RecoverExchange(exName, exchangeType, props)
+				v.RecoverExchange(exName, exchangeType, props, bindings)
 			}
 		}
 		queuesDir := filepath.Join(vhostsDir, vhostName, "queues")

--- a/internal/core/broker/vhost/binding.go
+++ b/internal/core/broker/vhost/binding.go
@@ -34,16 +34,17 @@ func (vh *VHost) BindQueue(exchangeName, queueName, routingKey string) error {
 			}
 		}
 		exchange.Bindings[routingKey] = append(exchange.Bindings[routingKey], queue)
+
 	case FANOUT:
 		exchange.Queues[queueName] = queue
 	}
 
-	// // Persist the state
-	// err := vh.saveBrokerState()
-	// if err != nil {
-	// 	log.Printf("Failed to save broker state: %v", err)
-	// }
-	// vh.publishBindingUpdate(exchangeName)
+	if exchange.Props.Durable && queue.Props.Durable {
+		err := vh.persist.SaveBindingState(vh.Name, exchangeName, queueName, routingKey, exchange.Props.Arguments)
+		if err != nil {
+			log.Printf("Failed to save binding state: %v", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/core/broker/vhost/consumer.go
+++ b/internal/core/broker/vhost/consumer.go
@@ -235,7 +235,7 @@ func (vh *VHost) CleanupConnection(connection net.Conn) {
 		err := vh.CancelConsumer(consumer.Channel, consumer.Tag)
 		vh.mu.Lock()
 		if err != nil {
-			fmt.Printf("Error cancelling consumer %s on channel %d: %v\n", consumer.Tag, consumer.Channel, err)
+			log.Error().Str("consumer", consumer.Tag).Msg("Error cancelling consumer")
 		}
 	}
 }

--- a/internal/core/broker/vhost/delivery.go
+++ b/internal/core/broker/vhost/delivery.go
@@ -89,5 +89,12 @@ func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message) error {
 		}
 		return err
 	}
+
+	// Persistence
+	if consumer.Props.NoAck && vh.persist != nil && msg.Properties.DeliveryMode == amqp.PERSISTENT {
+		if err := vh.persist.DeleteMessage(vh.Name, consumer.QueueName, msg.ID); err != nil {
+			log.Error().Err(err).Msg("Failed to delete persisted message after delivery with no-ack")
+		}
+	}
 	return nil
 }

--- a/internal/core/broker/vhost/message.go
+++ b/internal/core/broker/vhost/message.go
@@ -156,7 +156,7 @@ func (vh *VHost) saveMessageIfDurable(req SaveMessageRequest) error {
 				log.Error().Msg("Persistence layer is not initialized")
 				return fmt.Errorf("persistence layer is not initialized")
 			}
-			if err := vh.persist.SaveMessage(vh.Name, req.RoutingKey, req.MsgID, req.Body, req.MsgProps); err != nil {
+			if err := vh.persist.SaveMessage(vh.Name, req.Queue.Name, req.MsgID, req.Body, req.MsgProps); err != nil {
 				log.Error().Err(err).Msg("Failed to save message to file")
 				return err
 			}

--- a/internal/core/broker/vhost/recovery.go
+++ b/internal/core/broker/vhost/recovery.go
@@ -12,11 +12,9 @@ func (vh *VHost) RecoverExchange(name, typ string, props persistence.ExchangePro
 		Queues:   make(map[string]*Queue),
 		Bindings: make(map[string][]*Queue),
 		Props: &ExchangeProperties{
-			Passive:    props.Passive,
 			Durable:    props.Durable,
 			AutoDelete: props.AutoDelete,
 			Internal:   props.Internal,
-			NoWait:     props.NoWait,
 			Arguments:  props.Arguments,
 		},
 	}
@@ -37,7 +35,6 @@ func (vh *VHost) RecoverQueue(name string, props *persistence.QueueProperties) e
 	q := &Queue{
 		Name: name,
 		Props: &QueueProperties{
-			Passive:    props.Passive,
 			Durable:    props.Durable,
 			Exclusive:  props.Exclusive,
 			AutoDelete: props.AutoDelete,

--- a/internal/core/broker/vhost/recovery.go
+++ b/internal/core/broker/vhost/recovery.go
@@ -5,7 +5,7 @@ import (
 	"github.com/andrelcunha/ottermq/pkg/persistence"
 )
 
-func (vh *VHost) RecoverExchange(name, typ string, props persistence.ExchangeProperties) {
+func (vh *VHost) RecoverExchange(name, typ string, props persistence.ExchangeProperties, bindings []persistence.BindingData) {
 	ex := &Exchange{
 		Name:     name,
 		Typ:      ExchangeType(typ),
@@ -20,8 +20,16 @@ func (vh *VHost) RecoverExchange(name, typ string, props persistence.ExchangePro
 			Arguments:  props.Arguments,
 		},
 	}
+
+	for _, binding := range bindings {
+		queue, ok := vh.Queues[binding.QueueName]
+		if !ok {
+			continue
+		}
+		ex.Bindings[binding.RoutingKey] = append(ex.Bindings[binding.RoutingKey], queue)
+	}
+
 	vh.Exchanges[ex.Name] = ex
-	// TODO Recreate bindings
 }
 
 // RecoverQueue recreates a queue from its persisted state

--- a/internal/core/broker/vhost/reject.go
+++ b/internal/core/broker/vhost/reject.go
@@ -1,0 +1,44 @@
+package vhost
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/rs/zerolog/log"
+)
+
+func (vh *VHost) HandleBasicReject(conn net.Conn, channel uint16, deliveryTag uint64, requeue bool) error {
+	key := ConnectionChannelKey{conn, channel}
+
+	vh.mu.Lock()
+	ch := vh.ChannelDeliveries[key]
+	vh.mu.Unlock()
+	if ch == nil {
+		return fmt.Errorf("no channel delivery state for channel %d", channel)
+	}
+
+	ch.mu.Lock()
+	record, exists := ch.Unacked[deliveryTag]
+	if exists {
+		delete(ch.Unacked, deliveryTag)
+	}
+	ch.mu.Unlock()
+
+	if requeue {
+		log.Debug().Msgf("Requeuing message with delivery tag %d on channel %d\n", deliveryTag, channel)
+		vh.mu.Lock()
+		queue := vh.Queues[record.QueueName]
+		vh.mu.Unlock()
+		if queue != nil {
+			queue.Push(record.Message)
+		}
+	} else {
+		// TODO: implement dead-lettering
+		log.Debug().Msgf("Discarding message with delivery tag %d on channel %d\n", deliveryTag, channel)
+		if record.Persistent {
+			// TODO: persist discard if necessary
+			log.Debug().Msgf("Message with delivery tag %d was persistent, consider persisting discard\n", deliveryTag)
+		}
+	}
+	return nil
+}

--- a/internal/core/broker/vhost/reject.go
+++ b/internal/core/broker/vhost/reject.go
@@ -36,7 +36,7 @@ func (vh *VHost) HandleBasicReject(conn net.Conn, channel uint16, deliveryTag ui
 		// TODO: implement dead-lettering
 		log.Debug().Msgf("Discarding message with delivery tag %d on channel %d\n", deliveryTag, channel)
 		if record.Persistent {
-			// TODO: persist discard if necessary
+			_ = vh.persist.DeleteMessage(vh.Name, record.QueueName, record.Message.ID)
 			log.Debug().Msgf("Message with delivery tag %d was persistent, consider persisting discard\n", deliveryTag)
 		}
 	}

--- a/internal/core/broker/vhost/vhost.go
+++ b/internal/core/broker/vhost/vhost.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/andrelcunha/ottermq/internal/core/amqp"
 	"github.com/andrelcunha/ottermq/internal/persistdb"
@@ -98,6 +99,43 @@ func (vh *VHost) loadPersistedState() {
 	if vh.persist == nil {
 		return
 	}
+	// Load queues
+	queues, err := vh.persist.LoadAllQueues(vh.Name)
+	if err != nil {
+		panic("failed to load queues")
+	}
+	for _, queue := range queues {
+		vh.Queues[queue.Name] = NewQueue(queue.Name, vh.queueBufferSize)
+		vh.Queues[queue.Name].Props = &QueueProperties{
+			Durable:    queue.Properties.Durable,
+			AutoDelete: queue.Properties.AutoDelete,
+			Exclusive:  queue.Properties.Exclusive,
+			Arguments:  queue.Properties.Arguments,
+		}
+		// Load messages into the queue
+		for _, msgData := range queue.Messages {
+			msg := amqp.Message{
+				ID:   msgData.ID,
+				Body: msgData.Body,
+				Properties: amqp.BasicProperties{
+					ContentType:     amqp.ContentType(msgData.Properties.ContentType),
+					ContentEncoding: msgData.Properties.ContentEncoding,
+					Headers:         msgData.Properties.Headers,
+					DeliveryMode:    amqp.DeliveryMode(msgData.Properties.DeliveryMode),
+					Priority:        msgData.Properties.Priority,
+					CorrelationID:   msgData.Properties.CorrelationID,
+					ReplyTo:         msgData.Properties.ReplyTo,
+					Expiration:      msgData.Properties.Expiration,
+					MessageID:       msgData.Properties.MessageID,
+					Timestamp:       time.Unix(msgData.Properties.Timestamp, 0),
+					Type:            msgData.Properties.Type,
+					UserID:          msgData.Properties.UserID,
+					AppID:           msgData.Properties.AppID,
+				},
+			}
+			vh.Queues[queue.Name].Push(msg)
+		}
+	}
 
 	// Load exchanges
 	exchanges, err := vh.persist.LoadAllExchanges(vh.Name)
@@ -112,20 +150,8 @@ func (vh *VHost) loadPersistedState() {
 			Arguments:  exchange.Properties.Arguments,
 		}
 		vh.Exchanges[exchange.Name] = NewExchange(exchange.Name, typ, props)
-	}
-
-	// Load queues
-	queues, err := vh.persist.LoadAllQueues(vh.Name)
-	if err != nil {
-		panic("failed to load queues")
-	}
-	for _, queue := range queues {
-		vh.Queues[queue.Name] = NewQueue(queue.Name, vh.queueBufferSize)
-		vh.Queues[queue.Name].Props = &QueueProperties{
-			Durable:    queue.Properties.Durable,
-			AutoDelete: queue.Properties.AutoDelete,
-			Exclusive:  queue.Properties.Exclusive,
-			Arguments:  queue.Properties.Arguments,
+		for _, bindingData := range exchange.Bindings {
+			vh.BindQueue(exchange.Name, bindingData.QueueName, bindingData.RoutingKey)
 		}
 	}
 }

--- a/internal/core/broker/vhost/vhost.go
+++ b/internal/core/broker/vhost/vhost.go
@@ -103,7 +103,7 @@ func (vh *VHost) loadPersistedState() {
 	// Load queues
 	queues, err := vh.persist.LoadAllQueues(vh.Name)
 	if err != nil {
-		panic("failed to load queues")
+		log.Error().Err(err).Msg("Failed to load queues from persistence")
 	}
 	for _, queue := range queues {
 		vh.Queues[queue.Name] = NewQueue(queue.Name, vh.queueBufferSize)

--- a/pkg/persistence/implementations/dummy/dummy.go
+++ b/pkg/persistence/implementations/dummy/dummy.go
@@ -19,7 +19,15 @@ func (d *DummyPersistence) LoadQueueMetadata(vhost, name string) (persistence.Qu
 	return persistence.QueueProperties{}, nil
 }
 func (d *DummyPersistence) DeleteQueueMetadata(vhost, name string) error { return nil }
-
+func (d *DummyPersistence) SaveBindingState(vhost, exchange, queue, routingKey string, arguments map[string]any) error {
+	return nil
+}
+func (d *DummyPersistence) LoadExchangeBindings(vhost, exchange string) ([]persistence.BindingData, error) {
+	return nil, nil
+}
+func (d *DummyPersistence) DeleteBindingState(vhost, exchange, queue, routingKey string) error {
+	return nil
+}
 func (d *DummyPersistence) Initialize() error { return nil }
 func (d *DummyPersistence) Close() error      { return nil }
 

--- a/pkg/persistence/implementations/dummy/dummy.go
+++ b/pkg/persistence/implementations/dummy/dummy.go
@@ -28,6 +28,12 @@ func (d *DummyPersistence) LoadExchangeBindings(vhost, exchange string) ([]persi
 func (d *DummyPersistence) DeleteBindingState(vhost, exchange, queue, routingKey string) error {
 	return nil
 }
+func (d *DummyPersistence) LoadAllExchanges(vhost string) ([]persistence.ExchangeSnapshot, error) {
+	return nil, nil
+}
+func (d *DummyPersistence) LoadAllQueues(vhost string) ([]persistence.QueueSnapshot, error) {
+	return nil, nil
+}
 func (d *DummyPersistence) Initialize() error { return nil }
 func (d *DummyPersistence) Close() error      { return nil }
 

--- a/pkg/persistence/implementations/dummy/dummy.go
+++ b/pkg/persistence/implementations/dummy/dummy.go
@@ -46,3 +46,6 @@ func (d *DummyPersistence) LoadMessages(vhost, queue string) ([]persistence.Mess
 func (d *DummyPersistence) SaveMessage(vhost, queue, msgId string, msgBody []byte, msgProps persistence.MessageProperties) error {
 	return nil
 }
+func (d *DummyPersistence) DeleteMessage(vhost, queue, msgId string) error {
+	return nil
+}

--- a/pkg/persistence/implementations/json/json.go
+++ b/pkg/persistence/implementations/json/json.go
@@ -288,6 +288,29 @@ func (jp *JsonPersistence) LoadMessages(vhostName, queueName string) ([]persiste
 	return messages, nil
 }
 
+func (jp *JsonPersistence) DeleteMessage(vhost, queue, msgId string) error {
+	qData, err := jp.loadQueueFile(vhost, queue)
+	if err != nil {
+		return fmt.Errorf("queue not found: %v", err)
+	}
+
+	filtered := qData.Messages[:0]
+	removed := false
+	for _, msg := range qData.Messages {
+		if msg.ID == msgId {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, msg)
+	}
+	if !removed {
+		return nil
+	}
+	qData.Messages = filtered
+
+	return jp.saveQueueFile(vhost, queue, qData)
+}
+
 func (jp *JsonPersistence) LoadAllExchanges(vhost string) ([]persistence.ExchangeSnapshot, error) {
 	safeName := safeVHostName(vhost)
 	dir := filepath.Join(jp.dataDir, "vhosts", safeName, "exchanges")

--- a/pkg/persistence/implementations/json/json_test.go
+++ b/pkg/persistence/implementations/json/json_test.go
@@ -39,7 +39,6 @@ func TestSaveLoadExchange(t *testing.T) {
 		Durable:    true,
 		AutoDelete: false,
 		Internal:   false,
-		NoWait:     false,
 		Arguments:  nil,
 	}
 	exchange := &JsonExchangeData{
@@ -84,7 +83,6 @@ func TestSaveLoadQueue(t *testing.T) {
 	}
 	vhostName := "vhost/test"
 	props := persistence.QueueProperties{
-		Passive:    false,
 		Durable:    true,
 		Exclusive:  false,
 		AutoDelete: false,
@@ -130,7 +128,6 @@ func TestDeleteExchange(t *testing.T) {
 		Durable:    true,
 		AutoDelete: false,
 		Internal:   false,
-		NoWait:     false,
 		Arguments:  nil,
 	}
 	exchange := &JsonExchangeData{
@@ -172,7 +169,6 @@ func TestDeleteQueue(t *testing.T) {
 	}
 	vhostName := "vhost/test"
 	props := persistence.QueueProperties{
-		Passive:    false,
 		Durable:    true,
 		Exclusive:  false,
 		AutoDelete: false,

--- a/pkg/persistence/implementations/json/json_test.go
+++ b/pkg/persistence/implementations/json/json_test.go
@@ -46,7 +46,7 @@ func TestSaveLoadExchange(t *testing.T) {
 		Name:       "test-exchange",
 		Type:       "direct",
 		Properties: props,
-		Bindings:   []JsonBindingData{{QueueName: "q1", RoutingKey: "rk", Arguments: nil}},
+		Bindings:   []persistence.BindingData{{QueueName: "q1", RoutingKey: "rk", Arguments: nil}},
 	}
 	err = jsonPersistence.SaveExchangeMetadata(vhostName, exchange.Name, exchange.Type, exchange.Properties)
 	if err != nil {
@@ -292,5 +292,94 @@ func TestSaveLoadMessages(t *testing.T) {
 		if actual.Properties.ContentType != expected.Properties.ContentType {
 			t.Errorf("Message %d: expected content type %s, got %s", i, expected.Properties.ContentType, actual.Properties.ContentType)
 		}
+	}
+}
+
+func TestBindings_SaveLoad_Deduplicate_Delete(t *testing.T) {
+	tempDir := t.TempDir()
+	config := persistence.Config{Type: "json", DataDir: tempDir}
+	jsonPersistence, err := NewJsonPersistence(&config)
+	if err != nil {
+		t.Fatalf("Failed to create JSON persistence: %v", err)
+	}
+
+	vhostName := "/"
+	exchangeName := "ex-bindings"
+	exProps := persistence.ExchangeProperties{Durable: true}
+
+	// Save exchange metadata first
+	if err := jsonPersistence.SaveExchangeMetadata(vhostName, exchangeName, "direct", exProps); err != nil {
+		t.Fatalf("SaveExchangeMetadata failed: %v", err)
+	}
+
+	args := map[string]any{"x": 1}
+	// Save single binding
+	if err := jsonPersistence.SaveBindingState(vhostName, exchangeName, "q1", "rk1", args); err != nil {
+		t.Fatalf("SaveBindingState failed: %v", err)
+	}
+
+	// Load and verify
+	bindings, err := jsonPersistence.LoadExchangeBindings(vhostName, exchangeName)
+	if err != nil {
+		t.Fatalf("LoadExchangeBindings failed: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("expected 1 binding, got %d", len(bindings))
+	}
+	if bindings[0].QueueName != "q1" || bindings[0].RoutingKey != "rk1" || !equalArgs(bindings[0].Arguments, args) {
+		t.Errorf("unexpected binding loaded: %+v", bindings[0])
+	}
+	// Saving the same binding again should deduplicate (no duplicates added)
+	if err := jsonPersistence.SaveBindingState(vhostName, exchangeName, "q1", "rk1", args); err != nil {
+		t.Fatalf("SaveBindingState duplicate failed: %v", err)
+	}
+	bindings, err = jsonPersistence.LoadExchangeBindings(vhostName, exchangeName)
+	if err != nil {
+		t.Fatalf("LoadExchangeBindings failed: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("expected 1 binding after duplicate save, got %d", len(bindings))
+	}
+
+	// Add a second, distinct binding
+	if err := jsonPersistence.SaveBindingState(vhostName, exchangeName, "q2", "rk2", nil); err != nil {
+		t.Fatalf("SaveBindingState (second) failed: %v", err)
+	}
+	bindings, err = jsonPersistence.LoadExchangeBindings(vhostName, exchangeName)
+	if err != nil {
+		t.Fatalf("LoadExchangeBindings failed: %v", err)
+	}
+	if len(bindings) != 2 {
+		t.Fatalf("expected 2 bindings, got %d", len(bindings))
+	}
+
+	// Delete the second binding
+	if err := jsonPersistence.DeleteBindingState(vhostName, exchangeName, "q2", "rk2"); err != nil {
+		t.Fatalf("DeleteBindingState failed: %v", err)
+	}
+	bindings, err = jsonPersistence.LoadExchangeBindings(vhostName, exchangeName)
+	if err != nil {
+		t.Fatalf("LoadExchangeBindings failed: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("expected 1 binding after delete, got %d", len(bindings))
+	}
+	if bindings[0].QueueName != "q1" || bindings[0].RoutingKey != "rk1" {
+		t.Errorf("unexpected remaining binding: %+v", bindings[0])
+	}
+}
+
+func TestBindings_SaveBindingRequiresExchange(t *testing.T) {
+	tempDir := t.TempDir()
+	config := persistence.Config{Type: "json", DataDir: tempDir}
+	jsonPersistence, err := NewJsonPersistence(&config)
+	if err != nil {
+		t.Fatalf("Failed to create JSON persistence: %v", err)
+	}
+
+	vhostName := "/"
+	// Intentionally do not save exchange metadata
+	if err := jsonPersistence.SaveBindingState(vhostName, "non-existent", "q1", "rk1", nil); err == nil {
+		t.Fatalf("expected error saving binding for missing exchange, got nil")
 	}
 }

--- a/pkg/persistence/implementations/json/models.go
+++ b/pkg/persistence/implementations/json/models.go
@@ -14,17 +14,11 @@ type JsonQueueData struct {
 	Messages   []JsonMessageData           `json:"messages"`
 }
 
-type JsonBindingData struct {
-	QueueName  string         `json:"queue_name"`
-	RoutingKey string         `json:"routing_key"`
-	Arguments  map[string]any `json:"arguments"`
-}
-
 type JsonExchangeData struct {
 	Name       string                         `json:"name"`
 	Type       string                         `json:"type"`
 	Properties persistence.ExchangeProperties `json:"properties"`
-	Bindings   []JsonBindingData              `json:"bindings"`
+	Bindings   []persistence.BindingData      `json:"bindings"`
 }
 
 type JsonVHostData struct {

--- a/pkg/persistence/interface.go
+++ b/pkg/persistence/interface.go
@@ -2,20 +2,30 @@ package persistence
 
 // Persistence defines the interface for all storage backends
 type Persistence interface {
-	// Queue operations
-	SaveQueueMetadata(vhost, name string, props QueueProperties) error
+	/* Queue operations */
 
+	// SaveQueueMetadata saves a single queue's metadata to a JSON file (props)
+	SaveQueueMetadata(vhost, name string, props QueueProperties) error
 	// LoadQueueMetadata loads a single queue's metadata from a JSON file (props)
 	LoadQueueMetadata(vhost, name string) (props QueueProperties, err error)
+	// DeleteQueueMetadata deletes a single queue's metadata file
 	DeleteQueueMetadata(vhost, name string) error
 
-	// Exchange operations
+	/* Exchange operations */
+	// SaveExchangeMetadata saves exchange metadata to a JSON file (type and properties)
 	SaveExchangeMetadata(vhost, name, exchangeType string, props ExchangeProperties) error
-
 	// LoadExchangeMetadata loads exchange metadata from a JSON file (type and properties)
 	LoadExchangeMetadata(vhost, name string) (exchangeType string, props ExchangeProperties, err error)
-
+	// DeleteExchangeMetadata deletes a single exchange's metadata file
 	DeleteExchangeMetadata(vhost, name string) error
+
+	// Binding operations
+	// SaveBindingState saves a binding between an exchange and a queue
+	SaveBindingState(vhost, exchange, queue, routingKey string, arguments map[string]any) error
+	// LoadExchangeBindings loads a binding between an exchange and a queue
+	LoadExchangeBindings(vhost, exchange string) ([]BindingData, error)
+	// DeleteBindingState deletes a binding between an exchange and a queue
+	DeleteBindingState(vhost, exchange, queue, routingKey string) error
 
 	// Message operations (to be defined)
 	SaveMessage(vhost, queue, msgId string, msgBody []byte, msgProps MessageProperties) error

--- a/pkg/persistence/interface.go
+++ b/pkg/persistence/interface.go
@@ -30,6 +30,7 @@ type Persistence interface {
 	// Message operations (to be defined)
 	SaveMessage(vhost, queue, msgId string, msgBody []byte, msgProps MessageProperties) error
 	LoadMessages(vhostName, queueName string) ([]Message, error)
+	DeleteMessage(vhost, queue, msgId string) error
 
 	// Bulk recovery methods
 	LoadAllExchanges(vhost string) ([]ExchangeSnapshot, error)

--- a/pkg/persistence/interface.go
+++ b/pkg/persistence/interface.go
@@ -31,6 +31,10 @@ type Persistence interface {
 	SaveMessage(vhost, queue, msgId string, msgBody []byte, msgProps MessageProperties) error
 	LoadMessages(vhostName, queueName string) ([]Message, error)
 
+	// Bulk recovery methods
+	LoadAllExchanges(vhost string) ([]ExchangeSnapshot, error)
+	LoadAllQueues(vhost string) ([]QueueSnapshot, error)
+
 	// Lifecycle
 	Initialize() error
 	Close() error

--- a/pkg/persistence/models.go
+++ b/pkg/persistence/models.go
@@ -48,6 +48,19 @@ type BindingData struct {
 	Arguments  map[string]any `json:"arguments"`
 }
 
+type ExchangeSnapshot struct {
+	Name       string
+	Type       string
+	Properties ExchangeProperties
+	Bindings   []BindingData
+}
+
+type QueueSnapshot struct {
+	Name       string
+	Properties QueueProperties
+	Messages   []Message
+}
+
 // * Passive and NoWait are not needed in persistence
 // because they are only relevant during declaration time
 // Even though they are included here for completeness,

--- a/pkg/persistence/models.go
+++ b/pkg/persistence/models.go
@@ -42,6 +42,12 @@ type ExchangeProperties struct {
 	Arguments  map[string]any `json:"arguments"`
 }
 
+type BindingData struct {
+	QueueName  string         `json:"queue_name"`
+	RoutingKey string         `json:"routing_key"`
+	Arguments  map[string]any `json:"arguments"`
+}
+
 // * Passive and NoWait are not needed in persistence
 // because they are only relevant during declaration time
 // Even though they are included here for completeness,

--- a/pkg/persistence/models.go
+++ b/pkg/persistence/models.go
@@ -26,7 +26,6 @@ type Message struct {
 
 // Basic queue/exchange properties - universal concepts
 type QueueProperties struct {
-	Passive    bool           `json:"passive"` // Not needed in persistence*
 	Durable    bool           `json:"durable"`
 	Exclusive  bool           `json:"exclusive"`
 	AutoDelete bool           `json:"auto_delete"`
@@ -34,11 +33,9 @@ type QueueProperties struct {
 }
 
 type ExchangeProperties struct {
-	Passive    bool           `json:"passive"` // Not needed in persistence*
 	Durable    bool           `json:"durable"`
 	AutoDelete bool           `json:"auto_delete"`
 	Internal   bool           `json:"internal"`
-	NoWait     bool           `json:"no_wait"` // Not needed in persistence*
 	Arguments  map[string]any `json:"arguments"`
 }
 


### PR DESCRIPTION
Introduce support for BASIC_REJECT frame parsing, including handling for message requeueing and discarding. Implement persistence for exchange bindings and ensure recovery on startup. Strengthen message deletion logic and improve error handling during exchange and queue recovery. Add models for persisted topology and expose bulk recovery methods.