### PR TITLE
Add GitHub Pages documentation and enhance message recovery handling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,3 +104,23 @@ Currently uses JSON file storage with plans for **Memento WAL Engine**:
 - **Events vs State**: Memento will use append-only event log vs JSON's state snapshots
 
 Focus on **protocol compliance**, **connection lifecycle management**, and **stateful message assembly** when working with AMQP components. UI changes require understanding the REST API contract defined in `web/handlers/api/`.
+
+## Documentation & GitHub Pages
+
+We maintain a GitHub Pages site to track protocol/class/method support, roadmap notes, and user-facing documentation.
+
+- Public URL: https://ottermq.github.io/ottermq/
+- Source directory: `/docs`
+- Deployment branch: `pages` (Pages is configured to use `/docs` as the site root)
+
+Contributor workflow for Pages updates:
+1. When adding or changing AMQP support (new classes/methods, flags, error codes), or altering behavior that affects compatibility, update the relevant docs under `/docs` to reflect the new status.
+2. Commit documentation changes alongside code when reasonable, or in a follow-up PR before release.
+3. Open a PR targeting the `pages` branch (or cherry-pick docs commits to `pages`) so the site is deployed after merge.
+4. After merge, verify the site renders correctly and reflects the change at the public URL.
+
+PR checklist for protocol changes:
+- [ ] Updated `/docs` status matrices/tables for affected AMQP classes and methods
+- [ ] Added/updated notes on limitations, TODOs, or partial compliance
+- [ ] Cross-referenced the related code areas (`internal/core/amqp/*`, `internal/core/broker/*`) where applicable
+- [ ] If API or UI behavior changed, ensured Swagger docs (`make docs`) and any UI docs are updated

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # 🦦 OtterMQ
 
-[![Go](https://github.com/andrelcunha/OtterMq/actions/workflows/go.yml/badge.svg)](https://github.com/andrelcunha/OtterMq/actions/workflows/go.yml)
-[![Docker Image CI](https://github.com/andrelcunha/ottermq/actions/workflows/docker-image.yml/badge.svg)](https://github.com/andrelcunha/ottermq/actions/workflows/docker-image.yml)
-[![GitHub issues](https://img.shields.io/github/issues/andrelcunha/ottermq.svg)](https://github.com/andrelcunha/ottermq/issues)
-
+[![Go](https://github.com/ottermq/ottermq/actions/workflows/go.yml/badge.svg)](https://github.com/ottermq/ottermq/actions/workflows/go.yml)
+[![Docker Image CI](https://github.com/ottermq/ottermq/actions/workflows/docker-image.yml/badge.svg)](https://github.com/ottermq/ottermq/actions/workflows/docker-image.yml)
+[![GitHub issues](https://img.shields.io/github/issues/ottermq/ottermq.svg)](https://github.com/ottermq/ottermq/issues)
 
 **OtterMQ** is a high-performance message broker written in Go, inspired by RabbitMQ. It aims to provide a reliable, scalable, and easy-to-use messaging solution for distributed systems. OtterMQ is being developed with the goal of full compliance with the **AMQP 0.9.1 protocol**, ensuring compatibility with existing tools and workflows. It also features a modern management UI built with **Vue + Quasar**.
 
 OtterMq already supports basic interoperability with RabbitMQ clients, including:
+
 - [.NET RabbitMQ.Client](https://github.com/rabbitmq/rabbitmq-dotnet-client)
 - [github.com/rabbitmq/amqp091-go](https://github.com/rabbitmq/amqp091-go)
 
-
-
 ## 🐾 About the Name
+
 The name "OtterMQ" comes from my son's nickname and is a way to honor him. He brings joy and inspiration to my life, and this project is a reflection of that. And, of course, it is also a pun on **RabbitMQ**.
 
 ## ✨ Features
+
 - AMQP-style Message Queuing
 - Exchanges and Bindings
 - Pluggable Persistence Layer (JSON files, Memento WAL planned)
@@ -26,14 +26,17 @@ The name "OtterMQ" comes from my son's nickname and is a way to honor him. He br
 - RabbitMQ Client Compatibility (basic)
 
 ## ⚙️ Installation
+
 ```sh
-git clone https://github.com/andrelcunha/ottermq.git
+git clone https://github.com/ottermq/ottermq.git
 cd ottermq
 make build-all && make install
 ```
 
 ## 🚀 Usage
+
 ### Development Mode (UI runs separately)
+
 ```sh
 # Run the broker:
 make run-dev
@@ -44,6 +47,7 @@ quasar dev
 ```
 
 ### Production Mode (Integrated UI)
+
 ```sh
 # Build everything (UI + broker):
 make build-all
@@ -53,6 +57,7 @@ make run
 ```
 
 ### Available Commands
+
 ```sh
 make build           # Build broker only
 make build-all       # Build UI and broker (production ready)
@@ -63,6 +68,7 @@ make lint           # Run code quality checks
 make clean          # Clean all build artifacts
 make docs           # Generate API documentation
 ```
+
 OtterMq uses:
 
 - Port **5672** for the AMQP broker
@@ -70,9 +76,11 @@ OtterMq uses:
 - Port **3000** for the management UI
 
 ## ⚙️ Configuration
+
 OtterMQ can be configured using environment variables or a `.env` file. Environment variables take precedence over `.env` file settings, which in turn take precedence over default values.
 
 ### Configuration Options
+
 Copy `.env.example` to `.env` and customize as needed:
 
 ```sh
@@ -96,6 +104,7 @@ Available configuration options:
 | `OTTERMQ_JWT_SECRET` | `secret` | JWT secret key for authentication |
 
 ### Example Configuration
+
 Create a `.env` file in the project root:
 
 ```env
@@ -108,6 +117,7 @@ OTTERMQ_JWT_SECRET=my-secret-key
 ```
 
 Or use environment variables directly:
+
 ```sh
 export OTTERMQ_BROKER_PORT=15672
 export OTTERMQ_WEB_PORT=8080
@@ -115,13 +125,17 @@ ottermq
 ```
 
 ## 🐳 Docker
+
 You can run OtterMq using Docker:
+
 ```sh
 docker compose up --build
 ```
+
 This uses the provided `Dockerfile` and `docker-compose.yml` for convenience.
 
 ## 🚧 Development Status
+
 OtterMq is under active development. While it follows the AMQP 0.9.1 protocol, several features are still in progress or not yet implemented, including:
 
 - Message acknowledgments and recovery
@@ -133,18 +147,36 @@ OtterMq is under active development. While it follows the AMQP 0.9.1 protocol, s
 Basic compatibility with RabbitMQ clients is already functional, and more protocol features are being added incrementally. See [ROADMAP.md](ROADMAP.md) for detailed development plans.
 
 ## 📚 API Documentation
+
 OtterMq provides a built-in Swagger UI for exploring and testing the API.
 
 Access it at: `http://<server-address>/docs`
 
 If you make changes to the API and need to regenerate the documentation, run:
+
 ```sh
 make docs
 ```
+
 This will update the Swagger spec and refresh the documentation served at `/docs`.
 
+## 📄 Project Pages (Status & AMQP Compliance)
+
+We publish a live status site that tracks protocol/class/method support, planned work, and compatibility notes—similar to RabbitMQ’s specification page.
+
+- URL: [https://ottermq.github.io/ottermq/](https://ottermq.github.io/ottermq/)
+- Source location: the site content lives under the `/docs` folder
+- Deployment branch: `pages` (GitHub Pages is configured to build from `pages` with `/docs` as the site root)
+
+Notes:
+
+- The GitHub Pages site is separate from the Swagger UI served at `/docs` by the running server. The Pages site documents status and specs; the Swagger UI documents the REST API.
+- When adding or changing AMQP features (classes/methods), please also update the Pages content under `/docs` and merge it into the `pages` branch so the site stays current.
+
 ## ⚖️ License
-OtterMQ is released under the MIT License. See [License](https://github.com/andrelcunha/ottermq/blob/master/LICENSE) for more information.
+
+OtterMQ is released under the MIT License. See [License](https://github.com/ottermq/ottermq/blob/main/LICENSE) for more information.
 
 ## 💬 Contact
-For questions, suggestions, or issues, please open an issue in the [GitHub repository](https://github.com/andrelcunha/ottermq.git).
+
+For questions, suggestions, or issues, please open an issue in the [GitHub repository](https://github.com/ottermq/ottermq).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,15 @@
+title: OtterMQ
+description: High-performance AMQP 0.9.1 message broker with RabbitMQ compatibility
+# Built-in GitHub Pages theme
+theme: jekyll-theme-cayman
+
+# Site metadata
+url: https://ottermq.github.io/ottermq
+repository: ottermq/ottermq
+
+# Optional plugins supported by GitHub Pages
+plugins:
+  - jekyll-seo-tag
+
+# Kramdown is the default Markdown engine on GitHub Pages
+markdown: kramdown

--- a/docs/amqp-status.md
+++ b/docs/amqp-status.md
@@ -8,68 +8,116 @@ This page tracks OtterMQ's support for AMQP 0.9.1 classes and methods. It is int
 
 Status levels:
 
-- Implemented: Feature is available and tested
-- Partial: Some behavior is missing or differs from spec
-- Planned: Not yet implemented but on the roadmap
-- Not Supported: Out of scope or no plans yet
+- **Implemented**: Feature is available and tested
+- **Partial**: Some behavior is missing or differs from spec
+- **Planned**: Not yet implemented but on the roadmap
+- **Not Supported**: Out of scope or no plans yet
 
 ## Summary by Class
 
 | Class | Status | Notes |
 |------:|:------:|-------|
-| connection | Partial | Handshake and basic lifecycle supported; see details below |
-| channel | Partial | Basic open/close; see details |
-| exchange | Partial | direct/fanout/topic basics implemented |
-| queue | Partial | declare/bind basics implemented |
-| basic | Partial | push-based consume/deliver implemented |
+| connection | Partial | Handshake and basic lifecycle supported; blocked/unblocked not yet implemented |
+| channel | Partial | Basic open/close implemented; flow control not yet implemented |
+| exchange | Partial | direct/fanout/topic declare implemented; delete planned |
+| queue | Partial | declare/bind implemented; unbind/purge/delete planned |
+| basic | Partial | Most methods implemented; nack and qos missing |
 
 ## connection
 
 | Method | Status | Notes |
 |--------|:------:|------|
-| connection.start / start-ok | Implemented | |
-| connection.tune / tune-ok | Implemented | |
-| connection.open / open-ok | Implemented | |
-| connection.close / close-ok | Implemented | |
-| connection.blocked / unblocked | Planned | |
+| connection.start | Implemented | |
+| connection.start-ok | Implemented | |
+| connection.tune | Implemented | |
+| connection.tune-ok | Implemented | |
+| connection.open | Implemented | |
+| connection.open-ok | Implemented | |
+| connection.close | Implemented | |
+| connection.close-ok | Implemented | |
+| connection.blocked | Planned | |
+| connection.unblocked | Planned | |
 
 ## channel
 
 | Method | Status | Notes |
 |--------|:------:|------|
-| channel.open / open-ok | Implemented | |
-| channel.flow / flow-ok | Planned | |
-| channel.close / close-ok | Implemented | |
+| channel.open | Implemented | |
+| channel.open-ok | Implemented | |
+| channel.flow | Planned | Flow control not yet implemented |
+| channel.flow-ok | Planned | |
+| channel.close | Implemented | |
+| channel.close-ok | Implemented | |
 
 ## exchange
 
 | Method | Status | Notes |
 |--------|:------:|------|
-| exchange.declare / declare-ok | Partial | direct/fanout/topic |
-| exchange.delete / delete-ok | Planned | |
+| exchange.declare | Partial | Supports direct/fanout/topic; some optional properties may be missing |
+| exchange.declare-ok | Partial | |
+| exchange.delete | Planned | |
+| exchange.delete-ok | Planned | |
 
 ## queue
 
 | Method | Status | Notes |
 |--------|:------:|------|
-| queue.declare / declare-ok | Implemented | |
-| queue.bind / bind-ok | Implemented | |
-| queue.unbind / unbind-ok | Planned | |
-| queue.purge / purge-ok | Planned | |
-| queue.delete / delete-ok | Planned | |
+| queue.declare | Implemented | |
+| queue.declare-ok | Implemented | |
+| queue.bind | Implemented | |
+| queue.bind-ok | Implemented | |
+| queue.unbind | Planned | |
+| queue.unbind-ok | Planned | |
+| queue.purge | Planned | |
+| queue.purge-ok | Planned | |
+| queue.delete | Planned | |
+| queue.delete-ok | Planned | |
 
 ## basic
 
 | Method | Status | Notes |
 |--------|:------:|------|
+| basic.qos | Planned | Not yet implemented |
+| basic.qos-ok | Planned | |
+| basic.consume | Partial | noLocal not supported (same as RabbitMQ) |
+| basic.consume-ok | Partial | |
+| basic.cancel | Implemented | |
+| basic.cancel-ok | Implemented | |
 | basic.publish | Implemented | |
-| basic.consume / deliver | Implemented | Push-based delivery |
-| basic.get / get-ok | Planned | |
-| basic.ack / nack / reject | Planned | |
-| basic.recover / recover-ok | Planned | |
-| basic.qos / qos-ok | Planned | |
+| basic.return | Planned | Mandatory/immediate flags not fully handled |
+| basic.deliver | Implemented | |
+| basic.get | Implemented | Pull-based message retrieval |
+| basic.get-ok | Implemented | |
+| basic.get-empty | Implemented | |
+| basic.ack | Implemented | Supports multiple flag |
+| basic.reject | Partial | Requeue works; dead-lettering TODO |
+| basic.recover-async | Implemented | |
+| basic.recover | Implemented | |
+| basic.recover-ok | Implemented | |
+| basic.nack | Planned | Not yet implemented |
 
-Notes:
+## tx (Transactions)
+
+| Method | Status | Notes |
+|--------|:------:|------|
+| tx.select | Planned | Transaction support not yet implemented |
+| tx.select-ok | Planned | |
+| tx.commit | Planned | |
+| tx.commit-ok | Planned | |
+| tx.rollback | Planned | |
+| tx.rollback-ok | Planned | |
+
+## confirm (Publisher Confirms)
+
+| Method | Status | Notes |
+|--------|:------:|------|
+| confirm.select | Planned | Publisher confirms not yet implemented |
+| confirm.select-ok | Planned | |
+
+---
+
+**Notes:**
 
 - Keep this table in sync with the implementation in `internal/core/amqp/*` and `internal/core/broker/*`.
 - When adding or changing behavior, update the status and add notes on limitations or differences from RabbitMQ behavior.
+- "Partial" means one or more optional behaviors/properties are not yet implemented.

--- a/docs/amqp-status.md
+++ b/docs/amqp-status.md
@@ -1,0 +1,75 @@
+---
+title: AMQP 0.9.1 Support Status
+---
+
+## AMQP 0.9.1 Support Status
+
+This page tracks OtterMQ's support for AMQP 0.9.1 classes and methods. It is intended to help users understand current capabilities and to guide contributors.
+
+Status levels:
+
+- Implemented: Feature is available and tested
+- Partial: Some behavior is missing or differs from spec
+- Planned: Not yet implemented but on the roadmap
+- Not Supported: Out of scope or no plans yet
+
+## Summary by Class
+
+| Class | Status | Notes |
+|------:|:------:|-------|
+| connection | Partial | Handshake and basic lifecycle supported; see details below |
+| channel | Partial | Basic open/close; see details |
+| exchange | Partial | direct/fanout/topic basics implemented |
+| queue | Partial | declare/bind basics implemented |
+| basic | Partial | push-based consume/deliver implemented |
+
+## connection
+
+| Method | Status | Notes |
+|--------|:------:|------|
+| connection.start / start-ok | Implemented | |
+| connection.tune / tune-ok | Implemented | |
+| connection.open / open-ok | Implemented | |
+| connection.close / close-ok | Implemented | |
+| connection.blocked / unblocked | Planned | |
+
+## channel
+
+| Method | Status | Notes |
+|--------|:------:|------|
+| channel.open / open-ok | Implemented | |
+| channel.flow / flow-ok | Planned | |
+| channel.close / close-ok | Implemented | |
+
+## exchange
+
+| Method | Status | Notes |
+|--------|:------:|------|
+| exchange.declare / declare-ok | Partial | direct/fanout/topic |
+| exchange.delete / delete-ok | Planned | |
+
+## queue
+
+| Method | Status | Notes |
+|--------|:------:|------|
+| queue.declare / declare-ok | Implemented | |
+| queue.bind / bind-ok | Implemented | |
+| queue.unbind / unbind-ok | Planned | |
+| queue.purge / purge-ok | Planned | |
+| queue.delete / delete-ok | Planned | |
+
+## basic
+
+| Method | Status | Notes |
+|--------|:------:|------|
+| basic.publish | Implemented | |
+| basic.consume / deliver | Implemented | Push-based delivery |
+| basic.get / get-ok | Planned | |
+| basic.ack / nack / reject | Planned | |
+| basic.recover / recover-ok | Planned | |
+| basic.qos / qos-ok | Planned | |
+
+Notes:
+
+- Keep this table in sync with the implementation in `internal/core/amqp/*` and `internal/core/broker/*`.
+- When adding or changing behavior, update the status and add notes on limitations or differences from RabbitMQ behavior.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,37 @@
+---
+title: OtterMQ Project Overview
+---
+
+## 🦦 OtterMQ
+
+OtterMQ is a high-performance message broker written in Go, aiming for compatibility with the AMQP 0.9.1 protocol and interoperability with RabbitMQ clients. It includes a broker backend and a modern management UI built with Vue 3 + Quasar.
+
+This site tracks project status and documentation for users and contributors. For full source code and issue tracking, visit the GitHub repository:
+
+- Repository: [https://github.com/ottermq/ottermq](https://github.com/ottermq/ottermq)
+- Docker images and compose files are available in the repo
+
+## Quick links
+
+- AMQP 0.9.1 Support Status: [Status Matrix](./amqp-status)
+- REST API Swagger: served by the broker at `/docs` when running
+- Project README: [https://github.com/ottermq/ottermq#readme](https://github.com/ottermq/ottermq#readme)
+- Roadmap: [https://github.com/ottermq/ottermq/blob/main/ROADMAP.md](https://github.com/ottermq/ottermq/blob/main/ROADMAP.md)
+
+## Highlights
+
+- AMQP-style exchanges and queues
+- RabbitMQ client compatibility (basic)
+- Pluggable persistence layer (JSON today; Memento WAL planned)
+- Built-in management UI (Vue + Quasar)
+
+## Getting started
+
+- Build and run using `make build-all` then `make run`
+- Development: `make run-dev` for the broker and `quasar dev` for the UI in `ottermq_ui/`
+
+See the repository README for detailed steps and configuration options.
+
+## Contributing documentation
+
+Status pages live in this `/docs` folder and are deployed from the `pages` branch via GitHub Pages. When implementing or changing AMQP features (classes/methods), please keep the [Status Matrix](./amqp-status) up to date.

--- a/internal/core/amqp/framer.go
+++ b/internal/core/amqp/framer.go
@@ -19,6 +19,7 @@ type Framer interface {
 	CreateBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte
 	CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte
 	CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte
+	CreateBasicRecoverOkFrame(channel uint16) []byte
 
 	// Queue Methods
 	CreateQueueDeclareOkFrame(request *RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte
@@ -117,6 +118,10 @@ func (d *DefaultFramer) CreateBasicGetEmptyFrame(channel uint16) []byte {
 
 func (d *DefaultFramer) CreateBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte {
 	return createBasicGetOkFrame(channel, exchange, routingkey, msgCount)
+}
+
+func (d *DefaultFramer) CreateBasicRecoverOkFrame(channel uint16) []byte {
+	return createBasicRecoverOkFrame(channel)
 }
 
 func (d *DefaultFramer) CreateCloseFrame(channel, replyCode, classID, methodID, closeClassID, closeClassMethod uint16, replyText string) []byte {

--- a/internal/core/broker/basic_test.go
+++ b/internal/core/broker/basic_test.go
@@ -72,6 +72,9 @@ func (m *MockFramer) CreateBasicConsumeOkFrame(channel uint16, consumerTag strin
 func (m *MockFramer) CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
 	return []byte("basic-cancel-ok:" + consumerTag)
 }
+func (m *MockFramer) CreateBasicRecoverOkFrame(channel uint16) []byte {
+	return []byte("basic-recover-ok")
+}
 func (m *MockFramer) CreateQueueDeclareOkFrame(request *amqp.RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte {
 	return []byte("queue-declare")
 }

--- a/internal/core/broker/vhost/delivery.go
+++ b/internal/core/broker/vhost/delivery.go
@@ -22,7 +22,7 @@ type ChannelDeliveryState struct {
 	Unacked         map[uint64]*DeliveryRecord // deliveryTag -> DeliveryRecord
 }
 
-func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message) error {
+func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message, redelivered bool) error {
 	if !consumer.Active {
 		return fmt.Errorf("consumer %s on channel %d is not active", consumer.Tag, consumer.Channel)
 	}
@@ -57,7 +57,7 @@ func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message) error {
 		msg.Exchange,
 		msg.RoutingKey,
 		tag,
-		false, // redelivered - TODO: implement redelivery logic
+		redelivered,
 	)
 	headerFrame := vh.framer.CreateHeaderFrame(consumer.Channel, uint16(amqp.BASIC), msg)
 	bodyFrame := vh.framer.CreateBodyFrame(consumer.Channel, msg.Body)

--- a/internal/core/broker/vhost/delivery.go
+++ b/internal/core/broker/vhost/delivery.go
@@ -94,15 +94,15 @@ func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message, redeliv
 		return err
 	}
 
-	if redelivered {
-		vh.clearRedeliveredMark(msg.ID)
-	}
-
 	// Persistence
 	if consumer.Props.NoAck && vh.persist != nil && msg.Properties.DeliveryMode == amqp.PERSISTENT {
 		if err := vh.persist.DeleteMessage(vh.Name, consumer.QueueName, msg.ID); err != nil {
 			log.Error().Err(err).Msg("Failed to delete persisted message after delivery with no-ack")
 		}
+	}
+
+	if redelivered {
+		vh.clearRedeliveredMark(msg.ID)
 	}
 	return nil
 }

--- a/internal/core/broker/vhost/queue.go
+++ b/internal/core/broker/vhost/queue.go
@@ -69,7 +69,7 @@ func (q *Queue) startDeliveryLoop(vh *VHost) {
 					consumer := consumers[0]
 					vh.ConsumersByQueue[q.Name] = append(consumers[1:], consumer)
 					// TODO: improve delivery strategy using basic.qos and manual ack
-					if err := vh.deliverToConsumer(consumer, msg); err != nil {
+					if err := vh.deliverToConsumer(consumer, msg, false); err != nil {
 						log.Error().Err(err).Str("consumer", consumer.Tag).Msg("Delivery failed, removing consumer")
 						err := vh.CancelConsumer(consumer.Channel, consumer.Tag)
 						if err != nil {

--- a/internal/core/broker/vhost/recover.go
+++ b/internal/core/broker/vhost/recover.go
@@ -1,0 +1,86 @@
+package vhost
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/rs/zerolog/log"
+)
+
+// HandleBasicRecover processes a Basic.Recover AMQP frame, handling message requeueing if necessary.
+func (vh *VHost) HandleBasicRecover(conn net.Conn, channel uint16, requeue bool) error {
+	key := ConnectionChannelKey{conn, channel}
+
+	vh.mu.Lock()
+	ch := vh.ChannelDeliveries[key]
+	vh.mu.Unlock()
+	if ch == nil {
+		return fmt.Errorf("no channel delivery state for channel %d", channel)
+	}
+
+	ch.mu.Lock()
+	unackedMessages := make([]*DeliveryRecord, 0, len(ch.Unacked))
+	for _, record := range ch.Unacked {
+		unackedMessages = append(unackedMessages, record)
+	}
+	ch.Unacked = make(map[uint64]*DeliveryRecord)
+	ch.mu.Unlock()
+
+	for _, record := range unackedMessages {
+		if requeue {
+			log.Debug().Msgf("Requeuing message with delivery tag %d on channel %d\n", record.DeliveryTag, channel)
+			vh.mu.Lock()
+			queue := vh.Queues[record.QueueName]
+			vh.mu.Unlock()
+			if queue != nil {
+				// mark as redelivered for next delivery
+				vh.markAsRedelivered(record.Message.ID)
+				queue.Push(record.Message)
+			}
+		} else {
+			vh.mu.Lock()
+			consumerKey := ConnectionChannelKey{conn, channel}
+			consumers := vh.ConsumersByChannel[consumerKey]
+			vh.mu.Unlock()
+			var targetConsumer *Consumer
+			if len(consumers) > 0 {
+				for _, c := range consumers {
+					if c.Tag == record.ConsumerTag {
+						targetConsumer = c
+						break
+					}
+				}
+			}
+			if targetConsumer != nil {
+				err := vh.deliverToConsumer(targetConsumer, record.Message, true)
+				if err != nil {
+					// Delivery failed, requeue to avoid message loss
+					log.Debug().Err(err).Msg("Failed to redeliver recovered message, requeuing")
+					vh.mu.Lock()
+					q := vh.Queues[record.QueueName]
+					vh.mu.Unlock()
+					if q != nil {
+						q.Push(record.Message)
+					}
+				}
+			} else {
+				// consumer no longer exists, requeue
+				log.Debug().Str("consumer", record.ConsumerTag).Msgf("Consumer not found for recovered message, requeuing")
+				vh.mu.Lock()
+				q := vh.Queues[record.QueueName]
+				vh.mu.Unlock()
+				if q != nil {
+					vh.markAsRedelivered(record.Message.ID)
+					q.Push(record.Message)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (vh *VHost) markAsRedelivered(msgID string) {
+	vh.redeliveredMu.Lock()
+	vh.redeliveredMessages[msgID] = struct{}{}
+	vh.redeliveredMu.Unlock()
+}

--- a/internal/core/broker/vhost/recover.go
+++ b/internal/core/broker/vhost/recover.go
@@ -60,6 +60,7 @@ func (vh *VHost) HandleBasicRecover(conn net.Conn, channel uint16, requeue bool)
 					q := vh.Queues[record.QueueName]
 					vh.mu.Unlock()
 					if q != nil {
+						vh.markAsRedelivered(record.Message.ID)
 						q.Push(record.Message)
 					}
 				}

--- a/internal/core/broker/vhost/recover_test.go
+++ b/internal/core/broker/vhost/recover_test.go
@@ -1,0 +1,409 @@
+package vhost
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/andrelcunha/ottermq/internal/core/amqp"
+)
+
+func TestHandleBasicRecover_RequeueTrue(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	var conn net.Conn = nil
+
+	// Create queue
+	q, err := vh.CreateQueue("q1", nil)
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	// Setup channel delivery state with unacked messages
+	key := ConnectionChannelKey{conn, 1}
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+	vh.mu.Lock()
+	vh.ChannelDeliveries[key] = ch
+	vh.mu.Unlock()
+
+	// Add unacked messages
+	m1 := amqp.Message{ID: "msg1", Body: []byte("test1")}
+	m2 := amqp.Message{ID: "msg2", Body: []byte("test2")}
+
+	ch.mu.Lock()
+	ch.Unacked[1] = &DeliveryRecord{
+		DeliveryTag: 1,
+		ConsumerTag: "ctag1",
+		QueueName:   "q1",
+		Message:     m1,
+	}
+	ch.Unacked[2] = &DeliveryRecord{
+		DeliveryTag: 2,
+		ConsumerTag: "ctag1",
+		QueueName:   "q1",
+		Message:     m2,
+	}
+	ch.mu.Unlock()
+
+	// Call recover with requeue=true
+	if err := vh.HandleBasicRecover(conn, 1, true); err != nil {
+		t.Fatalf("HandleBasicRecover failed: %v", err)
+	}
+
+	// Verify unacked is cleared
+	ch.mu.Lock()
+	unackedCount := len(ch.Unacked)
+	ch.mu.Unlock()
+	if unackedCount != 0 {
+		t.Errorf("expected 0 unacked after recover, got %d", unackedCount)
+	}
+
+	// Verify messages requeued
+	if q.Len() != 2 {
+		t.Errorf("expected 2 messages in queue, got %d", q.Len())
+	}
+
+	// Verify messages marked as redelivered
+	if !vh.shouldRedeliver("msg1") {
+		t.Error("msg1 should be marked for redelivery")
+	}
+	if !vh.shouldRedeliver("msg2") {
+		t.Error("msg2 should be marked for redelivery")
+	}
+}
+
+func TestHandleBasicRecover_RequeueFalse_ConsumerExists(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	var conn net.Conn = nil
+
+	// Create queue
+	if _, err := vh.CreateQueue("q1", nil); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	// Register consumer
+	consumer := &Consumer{
+		Tag:        "ctag1",
+		Channel:    1,
+		QueueName:  "q1",
+		Connection: conn,
+		Active:     true,
+		Props:      &ConsumerProperties{NoAck: false},
+	}
+
+	consumerKey := ConsumerKey{Channel: 1, Tag: "ctag1"}
+	vh.mu.Lock()
+	vh.Consumers[consumerKey] = consumer
+	channelKey := ConnectionChannelKey{conn, 1}
+	vh.ConsumersByChannel[channelKey] = []*Consumer{consumer}
+	vh.mu.Unlock()
+
+	// Setup mock framer that always succeeds
+	vh.framer = &mockFramer{}
+
+	// Setup channel delivery state with unacked message
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+	vh.mu.Lock()
+	vh.ChannelDeliveries[channelKey] = ch
+	vh.mu.Unlock()
+
+	m1 := amqp.Message{ID: "msg1", Body: []byte("test1")}
+	ch.mu.Lock()
+	ch.LastDeliveryTag = 1 // Set counter so next delivery gets tag 2
+	ch.Unacked[1] = &DeliveryRecord{
+		DeliveryTag: 1,
+		ConsumerTag: "ctag1",
+		QueueName:   "q1",
+		Message:     m1,
+	}
+	ch.mu.Unlock()
+
+	// Call recover with requeue=false
+	if err := vh.HandleBasicRecover(conn, 1, false); err != nil {
+		t.Fatalf("HandleBasicRecover failed: %v", err)
+	}
+
+	// Verify new delivery was created with new tag (old tag 1 was cleared, new tag assigned)
+	ch.mu.Lock()
+	_, oldExists := ch.Unacked[1]
+	newUnackedCount := len(ch.Unacked)
+	var newTag uint64
+	for tag := range ch.Unacked {
+		newTag = tag
+		break
+	}
+	ch.mu.Unlock()
+
+	if oldExists {
+		t.Error("old delivery tag 1 should be cleared")
+	}
+	if newUnackedCount != 1 {
+		t.Errorf("expected 1 new unacked after redelivery, got %d", newUnackedCount)
+	}
+	if newTag != 2 {
+		t.Errorf("expected new delivery tag 2 (ch.LastDeliveryTag incremented from 1), got %d", newTag)
+	}
+}
+
+func TestHandleBasicRecover_RequeueFalse_ConsumerGone(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	var conn net.Conn = nil
+
+	// Create queue
+	q, err := vh.CreateQueue("q1", nil)
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	// Setup channel delivery state with unacked message, but NO consumer
+	key := ConnectionChannelKey{conn, 1}
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+	vh.mu.Lock()
+	vh.ChannelDeliveries[key] = ch
+	vh.mu.Unlock()
+
+	m1 := amqp.Message{ID: "msg1", Body: []byte("test1")}
+	ch.mu.Lock()
+	ch.Unacked[1] = &DeliveryRecord{
+		DeliveryTag: 1,
+		ConsumerTag: "ctag-missing",
+		QueueName:   "q1",
+		Message:     m1,
+	}
+	ch.mu.Unlock()
+
+	// Call recover with requeue=false
+	if err := vh.HandleBasicRecover(conn, 1, false); err != nil {
+		t.Fatalf("HandleBasicRecover failed: %v", err)
+	}
+
+	// Verify unacked is cleared
+	ch.mu.Lock()
+	unackedCount := len(ch.Unacked)
+	ch.mu.Unlock()
+	if unackedCount != 0 {
+		t.Errorf("expected 0 unacked after recover, got %d", unackedCount)
+	}
+
+	// Verify message requeued (fallback when consumer is gone)
+	if q.Len() != 1 {
+		t.Errorf("expected 1 message requeued, got %d", q.Len())
+	}
+
+	// Verify message marked as redelivered
+	if !vh.shouldRedeliver("msg1") {
+		t.Error("msg1 should be marked for redelivery")
+	}
+}
+
+func TestHandleBasicRecover_RequeueFalse_DeliveryFails(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	var conn net.Conn = nil
+
+	// Create queue
+	q, err := vh.CreateQueue("q1", nil)
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	// Register consumer
+	consumer := &Consumer{
+		Tag:        "ctag1",
+		Channel:    1,
+		QueueName:  "q1",
+		Connection: conn,
+		Active:     true,
+		Props:      &ConsumerProperties{NoAck: false},
+	}
+
+	consumerKey := ConsumerKey{Channel: 1, Tag: "ctag1"}
+	vh.mu.Lock()
+	vh.Consumers[consumerKey] = consumer
+	channelKey := ConnectionChannelKey{conn, 1}
+	vh.ConsumersByChannel[channelKey] = []*Consumer{consumer}
+	vh.mu.Unlock()
+
+	// Setup mock framer that FAILS
+	vh.framer = &mockFramerFail{}
+
+	// Setup channel delivery state with unacked message
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+	vh.mu.Lock()
+	vh.ChannelDeliveries[channelKey] = ch
+	vh.mu.Unlock()
+
+	m1 := amqp.Message{ID: "msg1", Body: []byte("test1")}
+	ch.mu.Lock()
+	ch.Unacked[1] = &DeliveryRecord{
+		DeliveryTag: 1,
+		ConsumerTag: "ctag1",
+		QueueName:   "q1",
+		Message:     m1,
+	}
+	ch.mu.Unlock()
+
+	// Call recover with requeue=false
+	if err := vh.HandleBasicRecover(conn, 1, false); err != nil {
+		t.Fatalf("HandleBasicRecover failed: %v", err)
+	}
+
+	// Verify old unacked is cleared
+	ch.mu.Lock()
+	unackedCount := len(ch.Unacked)
+	ch.mu.Unlock()
+	if unackedCount != 0 {
+		t.Errorf("expected 0 unacked after failed redelivery, got %d", unackedCount)
+	}
+
+	// Verify message requeued (fallback on delivery failure)
+	if q.Len() != 1 {
+		t.Errorf("expected 1 message requeued after failed delivery, got %d", q.Len())
+	}
+
+	// Verify message marked as redelivered
+	if !vh.shouldRedeliver("msg1") {
+		t.Error("msg1 should be marked for redelivery after failed delivery")
+	}
+}
+
+func TestHandleBasicRecover_NoChannelState(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	var conn net.Conn = nil
+
+	// Call recover without setting up channel state
+	err := vh.HandleBasicRecover(conn, 1, true)
+	if err == nil {
+		t.Error("expected error when channel state missing, got nil")
+	}
+}
+
+func TestRedeliveredMarkLifecycle(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+
+	// Mark a message as redelivered
+	vh.markAsRedelivered("msg1")
+
+	// Verify it's marked
+	if !vh.shouldRedeliver("msg1") {
+		t.Error("msg1 should be marked for redelivery")
+	}
+
+	// Clear the mark
+	vh.clearRedeliveredMark("msg1")
+
+	// Verify it's cleared
+	if vh.shouldRedeliver("msg1") {
+		t.Error("msg1 should not be marked after clearing")
+	}
+}
+
+// Mock framer that succeeds
+type mockFramer struct{}
+
+func (m *mockFramer) ReadFrame(conn net.Conn) ([]byte, error) { return nil, nil }
+func (m *mockFramer) ParseFrame(frame []byte) (any, error)    { return nil, nil }
+func (m *mockFramer) Handshake(configurations *map[string]any, conn net.Conn, connCtxt context.Context) (*amqp.ConnectionInfo, error) {
+	return nil, nil
+}
+func (m *mockFramer) CreateBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateHeaderFrame(channel, classID uint16, msg amqp.Message) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateBodyFrame(channel uint16, body []byte) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateBasicGetEmptyFrame(channel uint16) []byte { return []byte{} }
+func (m *mockFramer) CreateBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateQueueDeclareOkFrame(request *amqp.RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateQueueBindOkFrame(request *amqp.RequestMethodMessage) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateQueueDeleteOkFrame(request *amqp.RequestMethodMessage, messageCount uint32) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateExchangeDeclareFrame(request *amqp.RequestMethodMessage) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateExchangeDeleteFrame(request *amqp.RequestMethodMessage) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateChannelOpenOkFrame(request *amqp.RequestMethodMessage) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateChannelCloseOkFrame(channel uint16) []byte { return []byte{} }
+func (m *mockFramer) CreateConnectionCloseOkFrame(request *amqp.RequestMethodMessage) []byte {
+	return []byte{}
+}
+func (m *mockFramer) CreateCloseFrame(channel, replyCode, classID, methodID, closeClassID, closeClassMethod uint16, replyText string) []byte {
+	return []byte{}
+}
+func (m *mockFramer) SendFrame(conn net.Conn, frame []byte) error {
+	return nil // Success
+}
+
+// Mock framer that fails
+type mockFramerFail struct{}
+
+func (m *mockFramerFail) ReadFrame(conn net.Conn) ([]byte, error) { return nil, nil }
+func (m *mockFramerFail) ParseFrame(frame []byte) (any, error)    { return nil, nil }
+func (m *mockFramerFail) Handshake(configurations *map[string]any, conn net.Conn, connCtxt context.Context) (*amqp.ConnectionInfo, error) {
+	return nil, nil
+}
+func (m *mockFramerFail) CreateBasicDeliverFrame(channel uint16, consumerTag, exchange, routingKey string, deliveryTag uint64, redelivered bool) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateHeaderFrame(channel, classID uint16, msg amqp.Message) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateBodyFrame(channel uint16, body []byte) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateBasicGetEmptyFrame(channel uint16) []byte { return []byte{} }
+func (m *mockFramerFail) CreateBasicGetOkFrame(channel uint16, exchange, routingkey string, msgCount uint32) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateBasicConsumeOkFrame(channel uint16, consumerTag string) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateQueueDeclareOkFrame(request *amqp.RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateQueueBindOkFrame(request *amqp.RequestMethodMessage) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateQueueDeleteOkFrame(request *amqp.RequestMethodMessage, messageCount uint32) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateExchangeDeclareFrame(request *amqp.RequestMethodMessage) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateExchangeDeleteFrame(request *amqp.RequestMethodMessage) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateChannelOpenOkFrame(request *amqp.RequestMethodMessage) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateChannelCloseOkFrame(channel uint16) []byte { return []byte{} }
+func (m *mockFramerFail) CreateConnectionCloseOkFrame(request *amqp.RequestMethodMessage) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateCloseFrame(channel, replyCode, classID, methodID, closeClassID, closeClassMethod uint16, replyText string) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) SendFrame(conn net.Conn, frame []byte) error {
+	return &net.OpError{Op: "write", Err: net.ErrClosed}
+}

--- a/internal/core/broker/vhost/recover_test.go
+++ b/internal/core/broker/vhost/recover_test.go
@@ -323,6 +323,9 @@ func (m *mockFramer) CreateBasicConsumeOkFrame(channel uint16, consumerTag strin
 func (m *mockFramer) CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
 	return []byte{}
 }
+func (m *mockFramer) CreateBasicRecoverOkFrame(channel uint16) []byte {
+	return []byte{}
+}
 func (m *mockFramer) CreateQueueDeclareOkFrame(request *amqp.RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte {
 	return []byte{}
 }
@@ -377,6 +380,9 @@ func (m *mockFramerFail) CreateBasicConsumeOkFrame(channel uint16, consumerTag s
 	return []byte{}
 }
 func (m *mockFramerFail) CreateBasicCancelOkFrame(channel uint16, consumerTag string) []byte {
+	return []byte{}
+}
+func (m *mockFramerFail) CreateBasicRecoverOkFrame(channel uint16) []byte {
 	return []byte{}
 }
 func (m *mockFramerFail) CreateQueueDeclareOkFrame(request *amqp.RequestMethodMessage, queueName string, messageCount, consumerCount uint32) []byte {


### PR DESCRIPTION
Introduce GitHub Pages guidance and update repository links in documentation. Enhance message recovery handling by implementing Basic.Recover processing, tracking redelivered messages, and ensuring proper message requeuing to prevent loss. Include tests for the new functionality and clear redelivered marks after persistence handling. Update AMQP support status documentation.