### PR TITLE
Add Basic.Nack support and handling in broker

### DIFF
--- a/docs/amqp-status.md
+++ b/docs/amqp-status.md
@@ -21,7 +21,7 @@ Status levels:
 | channel | 67% | Basic open/close implemented; flow control not yet implemented |
 | exchange | 80% | direct/fanout declare implemented; missing topic |
 | queue | 55% | declare/bind implemented; unbind/purge/delete planned |
-| basic | 83% | Most methods implemented; nack and qos missing |
+| basic | 88% | Most methods implemented; nack and qos missing |
 | tx | 0% | |
 
 ## connection
@@ -93,7 +93,7 @@ Status levels:
 | basic.recover-async | ✅ | |
 | basic.recover | ✅ | |
 | basic.recover-ok | ✅ | |
-| basic.nack | ❌ | Not yet implemented |
+| basic.nack | ✅ | *not part of amqp 0-9-1 specs  |
 
 ## tx (Transactions)
 

--- a/docs/amqp-status.md
+++ b/docs/amqp-status.md
@@ -93,7 +93,7 @@ Status levels:
 | basic.recover-async | ✅ | |
 | basic.recover | ✅ | |
 | basic.recover-ok | ✅ | |
-| basic.nack | ✅ | *not part of amqp 0-9-1 specs  |
+| basic.nack | ✅ | *not part of amqp 0-9-1 specs |
 
 ## tx (Transactions)
 

--- a/internal/core/amqp/constants.go
+++ b/internal/core/amqp/constants.go
@@ -103,6 +103,7 @@ const (
 	BASIC_RECOVER_ASYNC BasicMethod = 100
 	BASIC_RECOVER       BasicMethod = 110
 	BASIC_RECOVER_OK    BasicMethod = 111
+	BASIC_NACK          BasicMethod = 120
 )
 
 type TxMethod int

--- a/internal/core/broker/vhost/delivery.go
+++ b/internal/core/broker/vhost/delivery.go
@@ -23,10 +23,10 @@ type ChannelDeliveryState struct {
 }
 
 func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message, redelivered bool) error {
+	// If caller didn't force redelivered, consult the mark set during requeue/recover.
 	if !redelivered {
 		redelivered = vh.shouldRedeliver(msg.ID)
 	}
-
 	if !consumer.Active {
 		return fmt.Errorf("consumer %s on channel %d is not active", consumer.Tag, consumer.Channel)
 	}
@@ -102,6 +102,7 @@ func (vh *VHost) deliverToConsumer(consumer *Consumer, msg amqp.Message, redeliv
 	}
 
 	if redelivered {
+		// Clear the one-shot mark so subsequent deliveries default to non-redelivered.
 		vh.clearRedeliveredMark(msg.ID)
 	}
 	return nil

--- a/internal/core/broker/vhost/nack_test.go
+++ b/internal/core/broker/vhost/nack_test.go
@@ -1,0 +1,212 @@
+package vhost
+
+import (
+	"net"
+	"testing"
+
+	"github.com/andrelcunha/ottermq/internal/core/amqp"
+	p "github.com/andrelcunha/ottermq/pkg/persistence"
+)
+
+// stubPersistence captures DeleteMessage calls for assertions
+type stubPersistence struct {
+	deletes []struct{ vhost, queue, msgId string }
+}
+
+func (s *stubPersistence) SaveExchangeMetadata(vhost, name, exchangeType string, props p.ExchangeProperties) error {
+	return nil
+}
+func (s *stubPersistence) LoadExchangeMetadata(vhost, name string) (string, p.ExchangeProperties, error) {
+	return "", p.ExchangeProperties{}, nil
+}
+func (s *stubPersistence) DeleteExchangeMetadata(vhost, name string) error { return nil }
+func (s *stubPersistence) SaveQueueMetadata(vhost, name string, props p.QueueProperties) error {
+	return nil
+}
+func (s *stubPersistence) LoadQueueMetadata(vhost, name string) (p.QueueProperties, error) {
+	return p.QueueProperties{}, nil
+}
+func (s *stubPersistence) DeleteQueueMetadata(vhost, name string) error { return nil }
+func (s *stubPersistence) SaveBindingState(vhost, exchange, queue, routingKey string, arguments map[string]any) error {
+	return nil
+}
+func (s *stubPersistence) LoadExchangeBindings(vhost, exchange string) ([]p.BindingData, error) {
+	return nil, nil
+}
+func (s *stubPersistence) DeleteBindingState(vhost, exchange, queue, routingKey string) error {
+	return nil
+}
+func (s *stubPersistence) SaveMessage(vhost, queue, msgId string, msgBody []byte, msgProps p.MessageProperties) error {
+	return nil
+}
+func (s *stubPersistence) LoadMessages(vhostName, queueName string) ([]p.Message, error) {
+	return nil, nil
+}
+func (s *stubPersistence) DeleteMessage(vhost, queue, msgId string) error {
+	s.deletes = append(s.deletes, struct{ vhost, queue, msgId string }{vhost, queue, msgId})
+	return nil
+}
+func (s *stubPersistence) LoadAllExchanges(vhost string) ([]p.ExchangeSnapshot, error) {
+	return nil, nil
+}
+func (s *stubPersistence) LoadAllQueues(vhost string) ([]p.QueueSnapshot, error) { return nil, nil }
+func (s *stubPersistence) Initialize() error                                     { return nil }
+func (s *stubPersistence) Close() error                                          { return nil }
+
+func TestHandleBasicNack_Single_RequeueTrue(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	// create queue
+	q, err := vh.CreateQueue("q1", nil)
+	if err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	// setup channel delivery state
+	var conn net.Conn = nil
+	key := ConnectionChannelKey{conn, 1}
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+	vh.mu.Lock()
+	vh.ChannelDeliveries[key] = ch
+	vh.mu.Unlock()
+
+	// add one unacked record
+	msg := amqp.Message{ID: "m5", Body: []byte("x")}
+	ch.mu.Lock()
+	ch.Unacked[5] = &DeliveryRecord{
+		DeliveryTag: 5,
+		ConsumerTag: "ctag",
+		QueueName:   "q1",
+		Message:     msg,
+		Persistent:  false,
+	}
+	ch.mu.Unlock()
+
+	if err := vh.HandleBasicNack(conn, 1, 5, false, true); err != nil {
+		t.Fatalf("HandleBasicNack failed: %v", err)
+	}
+
+	// Unacked should be cleared for tag 5
+	ch.mu.Lock()
+	_, exists := ch.Unacked[5]
+	ch.mu.Unlock()
+	if exists {
+		t.Error("expected delivery tag 5 to be removed from Unacked")
+	}
+
+	// Message requeued
+	if q.Len() != 1 {
+		t.Errorf("expected queue size 1, got %d", q.Len())
+	}
+
+	// Marked for redelivery
+	if !vh.shouldRedeliver("m5") {
+		t.Error("expected message m5 to be marked for redelivery")
+	}
+}
+
+func TestHandleBasicNack_Multiple_Boundary_DiscardPersistent(t *testing.T) {
+	sp := &stubPersistence{}
+	vh := NewVhost("test-vhost", 1000, sp)
+	// ensure queue exists (name referenced in records)
+	if _, err := vh.CreateQueue("q1", nil); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	var conn net.Conn = nil
+	key := ConnectionChannelKey{conn, 1}
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+	vh.mu.Lock()
+	vh.ChannelDeliveries[key] = ch
+	vh.mu.Unlock()
+
+	// tags 1..4, mark 1 and 2 as persistent to check deletion
+	msgs := []amqp.Message{
+		{ID: "m1"}, {ID: "m2"}, {ID: "m3"}, {ID: "m4"},
+	}
+	ch.mu.Lock()
+	ch.Unacked[1] = &DeliveryRecord{DeliveryTag: 1, ConsumerTag: "c", QueueName: "q1", Message: msgs[0], Persistent: true}
+	ch.Unacked[2] = &DeliveryRecord{DeliveryTag: 2, ConsumerTag: "c", QueueName: "q1", Message: msgs[1], Persistent: true}
+	ch.Unacked[3] = &DeliveryRecord{DeliveryTag: 3, ConsumerTag: "c", QueueName: "q1", Message: msgs[2], Persistent: false}
+	ch.Unacked[4] = &DeliveryRecord{DeliveryTag: 4, ConsumerTag: "c", QueueName: "q1", Message: msgs[3], Persistent: false}
+	ch.mu.Unlock()
+
+	// Nack up to tag 2 (<= 2), multiple=true, requeue=false
+	if err := vh.HandleBasicNack(conn, 1, 2, true, false); err != nil {
+		t.Fatalf("HandleBasicNack failed: %v", err)
+	}
+
+	// Expect tags 1,2 removed; 3,4 remain
+	ch.mu.Lock()
+	_, ex1 := ch.Unacked[1]
+	_, ex2 := ch.Unacked[2]
+	_, ex3 := ch.Unacked[3]
+	_, ex4 := ch.Unacked[4]
+	ch.mu.Unlock()
+
+	if ex1 || ex2 {
+		t.Error("expected tags 1 and 2 to be removed")
+	}
+	if !ex3 || !ex4 {
+		t.Error("expected tags 3 and 4 to remain")
+	}
+
+	// Expect persistence deletions for m1 and m2
+	if len(sp.deletes) != 2 {
+		t.Fatalf("expected 2 DeleteMessage calls, got %d", len(sp.deletes))
+	}
+	got := map[string]bool{}
+	for _, d := range sp.deletes {
+		got[d.msgId] = true
+	}
+	if !got["m1"] || !got["m2"] {
+		t.Errorf("expected deletes for m1 and m2, got %#v", sp.deletes)
+	}
+}
+
+func TestHandleBasicNack_NoChannelState(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	var conn net.Conn = nil
+	err := vh.HandleBasicNack(conn, 1, 1, false, true)
+	if err == nil {
+		t.Fatal("expected error when channel state missing, got nil")
+	}
+}
+
+func TestHandleBasicNack_Multiple_AboveBoundaryUnaffected(t *testing.T) {
+	vh := NewVhost("test-vhost", 1000, nil)
+	if _, err := vh.CreateQueue("q1", nil); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	var conn net.Conn = nil
+	key := ConnectionChannelKey{conn, 1}
+	ch := &ChannelDeliveryState{Unacked: make(map[uint64]*DeliveryRecord)}
+	vh.mu.Lock()
+	vh.ChannelDeliveries[key] = ch
+	vh.mu.Unlock()
+
+	// tags 1..4
+	ch.mu.Lock()
+	for i := uint64(1); i <= 4; i++ {
+		ch.Unacked[i] = &DeliveryRecord{DeliveryTag: i, ConsumerTag: "c", QueueName: "q1", Message: amqp.Message{ID: "m"}}
+	}
+	ch.mu.Unlock()
+
+	if err := vh.HandleBasicNack(conn, 1, 2, true, true); err != nil {
+		t.Fatalf("HandleBasicNack failed: %v", err)
+	}
+
+	// 1 and 2 removed, 3 and 4 remain
+	ch.mu.Lock()
+	_, ex1 := ch.Unacked[1]
+	_, ex2 := ch.Unacked[2]
+	_, ex3 := ch.Unacked[3]
+	_, ex4 := ch.Unacked[4]
+	ch.mu.Unlock()
+
+	if ex1 || ex2 {
+		t.Error("expected tags 1 and 2 to be removed")
+	}
+	if !ex3 || !ex4 {
+		t.Error("expected tags 3 and 4 to remain")
+	}
+}

--- a/internal/core/broker/vhost/recover.go
+++ b/internal/core/broker/vhost/recover.go
@@ -81,6 +81,8 @@ func (vh *VHost) HandleBasicRecover(conn net.Conn, channel uint16, requeue bool)
 }
 
 func (vh *VHost) markAsRedelivered(msgID string) {
+	// Mark message so the next Basic.Deliver will set redelivered=true.
+	// Cleared in deliverToConsumer after a successful delivery (one-shot).
 	vh.redeliveredMu.Lock()
 	vh.redeliveredMessages[msgID] = struct{}{}
 	vh.redeliveredMu.Unlock()

--- a/internal/core/broker/vhost/reject.go
+++ b/internal/core/broker/vhost/reject.go
@@ -43,7 +43,7 @@ func (vh *VHost) HandleBasicNack(conn net.Conn, channel uint16, deliveryTag uint
 
 	if requeue {
 		for _, record := range recordsToNack {
-			log.Debug().Msgf("Requeuing message with delivery tag %d on channel %d\n", deliveryTag, channel)
+			log.Debug().Msgf("Requeuing message with delivery tag %d on channel %d\n", record.DeliveryTag, channel)
 			vh.markAsRedelivered(record.Message.ID)
 			vh.mu.Lock()
 			queue := vh.Queues[record.QueueName]

--- a/internal/core/broker/vhost/reject.go
+++ b/internal/core/broker/vhost/reject.go
@@ -8,6 +8,10 @@ import (
 )
 
 func (vh *VHost) HandleBasicReject(conn net.Conn, channel uint16, deliveryTag uint64, requeue bool) error {
+	return vh.HandleBasicNack(conn, channel, deliveryTag, false, requeue)
+}
+
+func (vh *VHost) HandleBasicNack(conn net.Conn, channel uint16, deliveryTag uint64, multiple, requeue bool) error {
 	key := ConnectionChannelKey{conn, channel}
 
 	vh.mu.Lock()
@@ -18,26 +22,43 @@ func (vh *VHost) HandleBasicReject(conn net.Conn, channel uint16, deliveryTag ui
 	}
 
 	ch.mu.Lock()
-	record, exists := ch.Unacked[deliveryTag]
-	if exists {
-		delete(ch.Unacked, deliveryTag)
-	}
-	ch.mu.Unlock()
-
-	if requeue {
-		log.Debug().Msgf("Requeuing message with delivery tag %d on channel %d\n", deliveryTag, channel)
-		vh.mu.Lock()
-		queue := vh.Queues[record.QueueName]
-		vh.mu.Unlock()
-		if queue != nil {
-			queue.Push(record.Message)
+	recordsToNack := make([]*DeliveryRecord, 0)
+	if multiple {
+		for tag, record := range ch.Unacked {
+			if tag <= deliveryTag {
+				recordsToNack = append(recordsToNack, record)
+				delete(ch.Unacked, tag)
+			}
 		}
 	} else {
-		// TODO: implement dead-lettering
-		log.Debug().Msgf("Discarding message with delivery tag %d on channel %d\n", deliveryTag, channel)
+		if record, exists := ch.Unacked[deliveryTag]; exists {
+			recordsToNack = append(recordsToNack, record)
+			delete(ch.Unacked, deliveryTag)
+		}
+	}
+	ch.mu.Unlock()
+	if len(recordsToNack) == 0 {
+		return nil
+	}
+
+	if requeue {
+		for _, record := range recordsToNack {
+			log.Debug().Msgf("Requeuing message with delivery tag %d on channel %d\n", deliveryTag, channel)
+			vh.markAsRedelivered(record.Message.ID)
+			vh.mu.Lock()
+			queue := vh.Queues[record.QueueName]
+			vh.mu.Unlock()
+			if queue != nil {
+				queue.Push(record.Message)
+			}
+		}
+		return nil
+	}
+	// TODO: implement dead-lettering
+	for _, record := range recordsToNack {
+		log.Debug().Uint64("delivery_tag", record.DeliveryTag).Uint16("channel", channel).Msg("Nack: discarding message")
 		if record.Persistent {
 			_ = vh.persist.DeleteMessage(vh.Name, record.QueueName, record.Message.ID)
-			log.Debug().Msgf("Message with delivery tag %d was persistent, consider persisting discard\n", deliveryTag)
 		}
 	}
 	return nil


### PR DESCRIPTION
Introduce Basic.Nack support with validation and logging, enabling handling of multiple deliveries. Update documentation to clarify redelivery semantics and enhance test coverage for Basic.Nack functionality.