### PR TITLE
Add GitHub commit activity badge to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added GitHub commit activity badge to README
 - **Per-consumer unacked message tracking**: Implemented dual-index data structure (UnackedByConsumer + UnackedByTag) for O(1) consumer operations
 - **Consumer cancel E2E tests**: Added 6 comprehensive tests for consumer cancel behavior and edge cases
 - Automatic requeue of unacked messages when consumer is canceled (AMQP 0-9-1 spec compliance)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go](https://github.com/ottermq/ottermq/actions/workflows/go.yml/badge.svg)](https://github.com/ottermq/ottermq/actions/workflows/go.yml)
 [![Docker Image CI](https://github.com/ottermq/ottermq/actions/workflows/docker-image.yml/badge.svg)](https://github.com/ottermq/ottermq/actions/workflows/docker-image.yml)
+![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ottermq/ottermq)
 [![GitHub issues](https://img.shields.io/github/issues/ottermq/ottermq.svg)](https://github.com/ottermq/ottermq/issues)
 
 **OtterMQ** is a high-performance message broker written in Go, inspired by RabbitMQ. It aims to provide a reliable, scalable, and easy-to-use messaging solution for distributed systems. OtterMQ is being developed with the goal of full compliance with the **AMQP 0.9.1 protocol**, ensuring compatibility with existing tools and workflows. It also features a modern management UI built with **Vue + Quasar**.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go](https://github.com/ottermq/ottermq/actions/workflows/go.yml/badge.svg)](https://github.com/ottermq/ottermq/actions/workflows/go.yml)
 [![Docker Image CI](https://github.com/ottermq/ottermq/actions/workflows/docker-image.yml/badge.svg)](https://github.com/ottermq/ottermq/actions/workflows/docker-image.yml)
-![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ottermq/ottermq)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/m/ottermq/ottermq)]
 [![GitHub issues](https://img.shields.io/github/issues/ottermq/ottermq.svg)](https://github.com/ottermq/ottermq/issues)
 
 **OtterMQ** is a high-performance message broker written in Go, inspired by RabbitMQ. It aims to provide a reliable, scalable, and easy-to-use messaging solution for distributed systems. OtterMQ is being developed with the goal of full compliance with the **AMQP 0.9.1 protocol**, ensuring compatibility with existing tools and workflows. It also features a modern management UI built with **Vue + Quasar**.


### PR DESCRIPTION
Include a badge in the README to display the GitHub commit activity for the repository. This enhances visibility of the project's activity level.