### PR TITLE
Enable priority queues in setup with max priority configuration

### DIFF
--- a/internal/core/broker/vhost/queue.go
+++ b/internal/core/broker/vhost/queue.go
@@ -112,10 +112,11 @@ func (q *Queue) deliverFromPriorityQueue(vh *VHost) {
 		log.Debug().Str("queue", q.Name).Msg("Stopping delivery loop")
 		return
 	case <-q.messageSignal:
+		// There is at least one message in the priority queue
 		for q.Len() > 0 {
 			msg := q.Pop()
 			if msg == nil {
-				break
+				return
 			}
 			q.deliverMessage(vh, *msg)
 
@@ -124,7 +125,6 @@ func (q *Queue) deliverFromPriorityQueue(vh *VHost) {
 				return
 			}
 		}
-		return // Exit after processing all messages
 	}
 }
 

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -76,6 +76,7 @@ func setupBroker() error {
 		Password:        "guest",
 		LogLevel:        "warn",
 		QueueBufferSize: 100000,
+		MaxPriority:     10, // Enable priority queues (default: 10, max: 255)
 		JwtSecret:       "test-secret",
 		WebPort:         "3001", // Different port to avoid conflicts
 		DataDir:         testDataDir,


### PR DESCRIPTION
Configure the setup to enable priority queues with a maximum priority value, ensuring proper message delivery from the priority queue.