### PR TITLE
feat: user management CRUD endpoints

### DIFF
--- a/internal/persistdb/users.go
+++ b/internal/persistdb/users.go
@@ -3,6 +3,7 @@ package persistdb
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -87,6 +88,36 @@ var bcryptCost = 14
 func hashPassword(password string) (string, error) {
 	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
 	return string(bytes), err
+}
+
+func DeleteUser(username string) error {
+	result, err := db.Exec("DELETE FROM users WHERE username = ?", username)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to delete user")
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("user '%s' not found", username)
+	}
+	return nil
+}
+
+func ChangePassword(username, newPassword string) error {
+	hashed, err := hashPassword(newPassword)
+	if err != nil {
+		return err
+	}
+	result, err := db.Exec("UPDATE users SET password = ? WHERE username = ?", hashed, username)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to update password")
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("user '%s' not found", username)
+	}
+	return nil
 }
 
 func (u User) ToUserListDTO() (UserListDTO, error) {

--- a/web/docs/docs.go
+++ b/web/docs/docs.go
@@ -113,6 +113,175 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/users/{username}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a user by username",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.UserSummary"
+                        }
+                    },
+                    "401": {
+                        "description": "Missing or invalid JWT token",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a user by username",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Delete a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Missing or invalid JWT token",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/users/{username}/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the password for a user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Change user password",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New password",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.UserPasswordUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SuccessResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Missing or invalid JWT token",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/bindings": {
             "get": {
                 "security": [
@@ -3108,6 +3277,17 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/models.UserSummary"
                     }
+                }
+            }
+        },
+        "models.UserPasswordUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "confirm_password": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
                 }
             }
         },

--- a/web/handlers/api_admin/user.go
+++ b/web/handlers/api_admin/user.go
@@ -62,6 +62,89 @@ func GetUsers(c *fiber.Ctx) error {
 	return c.Status(fiber.StatusOK).JSON(models.UserListResponse{Users: out})
 }
 
+// GetUser godoc
+// @Summary Get a user
+// @Description Get a user by username
+// @Tags users
+// @Produce json
+// @Param username path string true "Username"
+// @Success 200 {object} models.UserSummary
+// @Failure 401 {object} models.UnauthorizedErrorResponse "Missing or invalid JWT token"
+// @Failure 404 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /admin/users/{username} [get]
+// @Security BearerAuth
+func GetUser(c *fiber.Ctx) error {
+	username := c.Params("username")
+	u, err := persistdb.GetUserByUsername(username)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(models.ErrorResponse{Error: "User not found"})
+	}
+	userdto, err := u.ToUserListDTO()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	return c.Status(fiber.StatusOK).JSON(models.FromPersistUserListDTO(userdto))
+}
+
+// DeleteUser godoc
+// @Summary Delete a user
+// @Description Delete a user by username
+// @Tags users
+// @Produce json
+// @Param username path string true "Username"
+// @Success 204
+// @Failure 401 {object} models.UnauthorizedErrorResponse "Missing or invalid JWT token"
+// @Failure 404 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /admin/users/{username} [delete]
+// @Security BearerAuth
+func DeleteUser(c *fiber.Ctx) error {
+	username := c.Params("username")
+	if err := persistdb.DeleteUser(username); err != nil {
+		status := fiber.StatusInternalServerError
+		if err.Error() == "user '"+username+"' not found" {
+			status = fiber.StatusNotFound
+		}
+		return c.Status(status).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// ChangePassword godoc
+// @Summary Change user password
+// @Description Update the password for a user
+// @Tags users
+// @Accept json
+// @Produce json
+// @Param username path string true "Username"
+// @Param body body models.UserPasswordUpdateRequest true "New password"
+// @Success 200 {object} models.SuccessResponse
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 401 {object} models.UnauthorizedErrorResponse "Missing or invalid JWT token"
+// @Failure 404 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /admin/users/{username}/password [put]
+// @Security BearerAuth
+func ChangePassword(c *fiber.Ctx) error {
+	username := c.Params("username")
+	var req models.UserPasswordUpdateRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	if req.Password != req.ConfirmPassword {
+		return c.Status(fiber.StatusBadRequest).JSON(models.ErrorResponse{Error: "Passwords do not match"})
+	}
+	if err := persistdb.ChangePassword(username, req.Password); err != nil {
+		status := fiber.StatusInternalServerError
+		if err.Error() == "user '"+username+"' not found" {
+			status = fiber.StatusNotFound
+		}
+		return c.Status(status).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	return c.Status(fiber.StatusOK).JSON(models.SuccessResponse{Message: "Password updated successfully"})
+}
+
 // Login godoc
 // @Summary Login
 // @Description Login

--- a/web/server.go
+++ b/web/server.go
@@ -208,6 +208,9 @@ func (ws *WebServer) AddAdminApi(app *fiber.App) {
 	apiAdminGrp.Use(middleware.AdminOnly)
 	apiAdminGrp.Get("/users", api_admin.GetUsers)
 	apiAdminGrp.Post("/users", api_admin.AddUser)
+	apiAdminGrp.Get("/users/:username", api_admin.GetUser)
+	apiAdminGrp.Delete("/users/:username", api_admin.DeleteUser)
+	apiAdminGrp.Put("/users/:username/password", api_admin.ChangePassword)
 }
 
 func (ws *WebServer) configServer(logFile *os.File) *fiber.App {


### PR DESCRIPTION
## Summary

Fills in the missing user management endpoints in the admin API.

- **`persistdb`**: added `DeleteUser(username)` and `ChangePassword(username, newPassword)` — both return a typed error when the user is not found
- **HTTP handlers** (`/api/admin/users`):
  - `GET /users/:username` — fetch a single user by username
  - `DELETE /users/:username` — delete a user (204 on success, 404 if not found)
  - `PUT /users/:username/password` — change password with confirmation check
- **Routes** wired in `server.go` under the existing admin group (JWT + AdminOnly middleware)
- **Swagger docs** regenerated via `make docs`

## Notes on the sync story

`VHost.Users` is a runtime display cache populated once at startup — it is not used for authentication. Both AMQP and HTTP login go through `persistdb.AuthenticateUser` directly, so no broker-level changes are needed for user CRUD.

## Test plan

- [ ] `go test ./...` passes
- [ ] `POST /api/admin/users` creates user, `GET /api/admin/users/:username` returns it
- [ ] `PUT /api/admin/users/:username/password` updates password, old password no longer authenticates
- [ ] `DELETE /api/admin/users/:username` removes user, subsequent `GET` returns 404
- [ ] `DELETE` on non-existent user returns 404