### PR TITLE
feat: vhost membership permissions (Option B)

### DIFF
--- a/cmd/ottermq/main.go
+++ b/cmd/ottermq/main.go
@@ -233,14 +233,20 @@ func setupUserDatabase(dataDir string, cfg *config.Config) (persistdb.User, erro
 	if err := persistdb.OpenDB(); err != nil {
 		log.Fatal().Err(err).Msg("Failed to open database")
 	}
+	// InitDB is idempotent (CREATE TABLE IF NOT EXISTS) — always run it so new
+	// tables added in later versions are created on existing databases too.
+	persistdb.InitDB()
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		log.Info().Msg("Database file not found. Creating a new one...")
-		persistdb.InitDB()
 		persistdb.AddDefaultRoles()
 		persistdb.AddDefaultPermissions()
 		user := persistdb.UserCreateDTO{Username: cfg.Username, Password: cfg.Password, RoleID: 1}
 		if err := persistdb.AddUser(user); err != nil {
 			log.Error().Err(err).Msg("Failed to add user")
+		}
+		// Grant default user access to the default vhost
+		if err := persistdb.GrantVHostAccess(cfg.Username, "/"); err != nil {
+			log.Error().Err(err).Msg("Failed to grant default vhost access")
 		}
 	}
 	user, err := persistdb.GetUserByUsername(cfg.Username)

--- a/internal/core/amqp/handshake.go
+++ b/internal/core/amqp/handshake.go
@@ -143,16 +143,19 @@ func handshake(configurations *map[string]any, conn net.Conn, connCtx context.Co
 	}
 
 	openFrame, _ := state.MethodFrame.Content.(*ConnectionOpen)
-	// TODO: #121 validate if the vhost exists - if not, raise connection exception - 402
-	// The challenge is that at this point we don't have access to the Broker struct
-	// We can return the VHostName in the ConnectionInfo struct and let the Broker handle it
-	// We could also pass a callback function to the handshake function to validate the vhost
-	// Or a list of valid vhosts in the configurations map
-
 	if openFrame == nil {
 		return nil, fmt.Errorf("type assertion ConnectionOpenFrame failed")
 	}
 	VHostName := openFrame.VirtualHost
+
+	// Enforce vhost membership: check that the authenticated user is allowed on this vhost.
+	username, _ := (*configurations)["username"].(string)
+	if username != "" {
+		ok, err := persistdb.HasVHostAccess(username, VHostName)
+		if err != nil || !ok {
+			return nil, fmt.Errorf("access to vhost '%s' denied for user '%s'", VHostName, username)
+		}
+	}
 
 	connInfo := NewConnectionInfo(VHostName)
 	connInfo.Client = client

--- a/internal/core/models/responses_user.go
+++ b/internal/core/models/responses_user.go
@@ -28,3 +28,12 @@ type UserResponse struct {
 type UnauthorizedErrorResponse struct {
 	Error string `json:"error"`
 }
+
+type PermissionDTO struct {
+	Username string `json:"username"`
+	VHost    string `json:"vhost"`
+}
+
+type PermissionListResponse struct {
+	Permissions []PermissionDTO `json:"permissions"`
+}

--- a/internal/persistdb/database.go
+++ b/internal/persistdb/database.go
@@ -69,6 +69,18 @@ func createTables() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create 'role_permissions' table")
 	}
+
+	createUserVHostsTable := `
+	CREATE TABLE IF NOT EXISTS user_vhosts (
+		username TEXT NOT NULL,
+		vhost TEXT NOT NULL,
+		PRIMARY KEY(username, vhost),
+		FOREIGN KEY(username) REFERENCES users(username) ON DELETE CASCADE
+	);`
+	_, err = db.Exec(createUserVHostsTable)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to create 'user_vhosts' table")
+	}
 }
 
 func OpenDB() error {

--- a/internal/persistdb/models.go
+++ b/internal/persistdb/models.go
@@ -37,3 +37,8 @@ type UserCreateDTO struct {
 	ConfirmPassword string `json:"confirm_password"`
 	RoleID          int    `json:"role"`
 }
+
+type VHostPermission struct {
+	Username string `json:"username"`
+	VHost    string `json:"vhost"`
+}

--- a/internal/persistdb/vhost_access.go
+++ b/internal/persistdb/vhost_access.go
@@ -1,0 +1,129 @@
+package persistdb
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+)
+
+// GrantVHostAccess gives a user access to a vhost.
+func GrantVHostAccess(username, vhost string) error {
+	_, err := db.Exec(
+		"INSERT OR IGNORE INTO user_vhosts (username, vhost) VALUES (?, ?)",
+		username, vhost,
+	)
+	if err != nil {
+		log.Error().Err(err).Str("username", username).Str("vhost", vhost).Msg("Failed to grant vhost access")
+	}
+	return err
+}
+
+// RevokeVHostAccess removes a user's access to a vhost.
+func RevokeVHostAccess(username, vhost string) error {
+	result, err := db.Exec(
+		"DELETE FROM user_vhosts WHERE username = ? AND vhost = ?",
+		username, vhost,
+	)
+	if err != nil {
+		log.Error().Err(err).Str("username", username).Str("vhost", vhost).Msg("Failed to revoke vhost access")
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("no permission found for user '%s' on vhost '%s'", username, vhost)
+	}
+	return nil
+}
+
+// HasVHostAccess reports whether a user has access to a vhost.
+// Admin users bypass the check and always return true.
+func HasVHostAccess(username, vhost string) (bool, error) {
+	// Admins have unrestricted access
+	u, err := GetUserByUsername(username)
+	if err != nil {
+		return false, err
+	}
+	role, err := GetRoleByID(u.RoleID)
+	if err != nil {
+		return false, err
+	}
+	if role.Name == "admin" {
+		return true, nil
+	}
+
+	var count int
+	err = db.QueryRow(
+		"SELECT COUNT(*) FROM user_vhosts WHERE username = ? AND vhost = ?",
+		username, vhost,
+	).Scan(&count)
+	if err != nil && err != sql.ErrNoRows {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// ListUserVHosts returns all vhosts a user has access to.
+func ListUserVHosts(username string) ([]string, error) {
+	rows, err := db.Query(
+		"SELECT vhost FROM user_vhosts WHERE username = ? ORDER BY vhost",
+		username,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var vhosts []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, err
+		}
+		vhosts = append(vhosts, v)
+	}
+	return vhosts, nil
+}
+
+// ListVHostUsers returns all users that have access to a vhost.
+func ListVHostUsers(vhost string) ([]string, error) {
+	rows, err := db.Query(
+		"SELECT username FROM user_vhosts WHERE vhost = ? ORDER BY username",
+		vhost,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []string
+	for rows.Next() {
+		var u string
+		if err := rows.Scan(&u); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, nil
+}
+
+// ListAllPermissions returns every user-vhost grant.
+func ListAllPermissions() ([]VHostPermission, error) {
+	rows, err := db.Query(
+		"SELECT username, vhost FROM user_vhosts ORDER BY vhost, username",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var perms []VHostPermission
+	for rows.Next() {
+		var p VHostPermission
+		if err := rows.Scan(&p.Username, &p.VHost); err != nil {
+			return nil, err
+		}
+		perms = append(perms, p)
+	}
+	return perms, nil
+}

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -105,6 +105,9 @@ func setupBroker() error {
 	if err := persistdb.AddUser(user); err != nil {
 		return fmt.Errorf("failed to add test user: %w", err)
 	}
+	if err := persistdb.GrantVHostAccess(cfg.Username, "/"); err != nil {
+		return fmt.Errorf("failed to grant vhost access: %w", err)
+	}
 	dbUser, err := persistdb.GetUserByUsername(cfg.Username)
 	if err != nil {
 		return fmt.Errorf("failed to get user: %w", err)

--- a/web/docs/docs.go
+++ b/web/docs/docs.go
@@ -15,6 +15,201 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/permissions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List every user-vhost access grant",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "permissions"
+                ],
+                "summary": "List all vhost permissions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.PermissionListResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/permissions/{vhost}/{username}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Check whether a user has access to a specific vhost",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "permissions"
+                ],
+                "summary": "Get vhost permission for a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VHost name",
+                        "name": "vhost",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.PermissionDTO"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Allow a user to connect to the specified vhost",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "permissions"
+                ],
+                "summary": "Grant vhost access to a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VHost name",
+                        "name": "vhost",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.PermissionDTO"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Remove a user's access to the specified vhost",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "permissions"
+                ],
+                "summary": "Revoke vhost access from a user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VHost name",
+                        "name": "vhost",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/users": {
             "get": {
                 "security": [
@@ -3060,6 +3255,28 @@ const docTemplate = `{
                 },
                 "queues": {
                     "type": "integer"
+                }
+            }
+        },
+        "models.PermissionDTO": {
+            "type": "object",
+            "properties": {
+                "username": {
+                    "type": "string"
+                },
+                "vhost": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.PermissionListResponse": {
+            "type": "object",
+            "properties": {
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.PermissionDTO"
+                    }
                 }
             }
         },

--- a/web/handlers/api_admin/permissions.go
+++ b/web/handlers/api_admin/permissions.go
@@ -1,0 +1,103 @@
+package api_admin
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/ottermq/ottermq/internal/core/models"
+	"github.com/ottermq/ottermq/internal/persistdb"
+)
+
+// ListPermissions godoc
+// @Summary List all vhost permissions
+// @Description List every user-vhost access grant
+// @Tags permissions
+// @Produce json
+// @Success 200 {object} models.PermissionListResponse
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /admin/permissions [get]
+// @Security BearerAuth
+func ListPermissions(c *fiber.Ctx) error {
+	perms, err := persistdb.ListAllPermissions()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	out := make([]models.PermissionDTO, 0, len(perms))
+	for _, p := range perms {
+		out = append(out, models.PermissionDTO{Username: p.Username, VHost: p.VHost})
+	}
+	return c.Status(fiber.StatusOK).JSON(models.PermissionListResponse{Permissions: out})
+}
+
+// GetPermission godoc
+// @Summary Get vhost permission for a user
+// @Description Check whether a user has access to a specific vhost
+// @Tags permissions
+// @Produce json
+// @Param vhost path string true "VHost name"
+// @Param username path string true "Username"
+// @Success 200 {object} models.PermissionDTO
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 404 {object} models.ErrorResponse
+// @Router /admin/permissions/{vhost}/{username} [get]
+// @Security BearerAuth
+func GetPermission(c *fiber.Ctx) error {
+	vhost := c.Params("vhost")
+	username := c.Params("username")
+	ok, err := persistdb.HasVHostAccess(username, vhost)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	if !ok {
+		return c.Status(fiber.StatusNotFound).JSON(models.ErrorResponse{
+			Error: "no permission found for user '" + username + "' on vhost '" + vhost + "'",
+		})
+	}
+	return c.Status(fiber.StatusOK).JSON(models.PermissionDTO{Username: username, VHost: vhost})
+}
+
+// GrantPermission godoc
+// @Summary Grant vhost access to a user
+// @Description Allow a user to connect to the specified vhost
+// @Tags permissions
+// @Produce json
+// @Param vhost path string true "VHost name"
+// @Param username path string true "Username"
+// @Success 201 {object} models.PermissionDTO
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /admin/permissions/{vhost}/{username} [put]
+// @Security BearerAuth
+func GrantPermission(c *fiber.Ctx) error {
+	vhost := c.Params("vhost")
+	username := c.Params("username")
+	if err := persistdb.GrantVHostAccess(username, vhost); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	return c.Status(fiber.StatusCreated).JSON(models.PermissionDTO{Username: username, VHost: vhost})
+}
+
+// RevokePermission godoc
+// @Summary Revoke vhost access from a user
+// @Description Remove a user's access to the specified vhost
+// @Tags permissions
+// @Produce json
+// @Param vhost path string true "VHost name"
+// @Param username path string true "Username"
+// @Success 204
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 404 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /admin/permissions/{vhost}/{username} [delete]
+// @Security BearerAuth
+func RevokePermission(c *fiber.Ctx) error {
+	vhost := c.Params("vhost")
+	username := c.Params("username")
+	if err := persistdb.RevokeVHostAccess(username, vhost); err != nil {
+		status := fiber.StatusInternalServerError
+		if err.Error() == "no permission found for user '"+username+"' on vhost '"+vhost+"'" {
+			status = fiber.StatusNotFound
+		}
+		return c.Status(status).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}

--- a/web/server.go
+++ b/web/server.go
@@ -211,6 +211,12 @@ func (ws *WebServer) AddAdminApi(app *fiber.App) {
 	apiAdminGrp.Get("/users/:username", api_admin.GetUser)
 	apiAdminGrp.Delete("/users/:username", api_admin.DeleteUser)
 	apiAdminGrp.Put("/users/:username/password", api_admin.ChangePassword)
+
+	// Permissions routes
+	apiAdminGrp.Get("/permissions", api_admin.ListPermissions)
+	apiAdminGrp.Get("/permissions/:vhost/:username", api_admin.GetPermission)
+	apiAdminGrp.Put("/permissions/:vhost/:username", api_admin.GrantPermission)
+	apiAdminGrp.Delete("/permissions/:vhost/:username", api_admin.RevokePermission)
 }
 
 func (ws *WebServer) configServer(logFile *os.File) *fiber.App {


### PR DESCRIPTION
## Summary

Implements simple vhost-level access control: a `user_vhosts` table tracks which users can connect to which vhosts. Admin role bypasses the check unconditionally.

### Layers

- **DB schema**: new `user_vhosts (username, vhost)` table added to `createTables()` — idempotent, safe on existing databases
- **`persistdb`**: `GrantVHostAccess`, `RevokeVHostAccess`, `HasVHostAccess`, `ListUserVHosts`, `ListVHostUsers`, `ListAllPermissions`
- **AMQP enforcement**: `handshake.go` calls `HasVHostAccess` after parsing `Connection.Open` — rejects the connection if the user is not allowed on the requested vhost
- **Startup**: `InitDB` is now called unconditionally (it's idempotent) so new tables appear on existing databases; default user is granted access to `/` on first run
- **HTTP API** (all under `AdminOnly`):
  - `GET /api/admin/permissions` — list all grants
  - `GET /api/admin/permissions/:vhost/:username` — check a specific grant
  - `PUT /api/admin/permissions/:vhost/:username` — grant access
  - `DELETE /api/admin/permissions/:vhost/:username` — revoke access
- **Swagger docs** regenerated

### Design notes

- Admin role bypasses all vhost checks (checked via `GetRoleByID` in `HasVHostAccess`)
- Non-admin users require an explicit grant per vhost
- Schema is extensible: configure/write/read columns can be added later for full RabbitMQ-compatible regex permissions

## Test plan

- [ ] `go test $(go list ./... | grep -v tests/e2e)` passes
- [ ] e2e suite passes in CI (no pre-existing broker on port 5672)
- [ ] Non-admin user without a grant cannot connect via AMQP to a vhost
- [ ] `PUT /api/admin/permissions/my-vhost/user1` grants access; user1 can then connect
- [ ] `DELETE /api/admin/permissions/my-vhost/user1` revokes it; connection denied again
- [ ] Admin user can always connect to any vhost regardless of grants