### PR TITLE
feat: health check command group

### DIFF
--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewHealthCmd(rt *Runtime) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "health",
+		Short: "Run broker health checks",
+	}
+
+	cmd.AddCommand(newHealthCheckAlarmsCmd(rt))
+	cmd.AddCommand(newHealthCheckLocalAlarmsCmd(rt))
+	cmd.AddCommand(newHealthCheckPortListenerCmd(rt))
+	cmd.AddCommand(newHealthCheckVirtualHostsCmd(rt))
+	cmd.AddCommand(newHealthCheckReadyCmd(rt))
+
+	return cmd
+}
+
+func newHealthCheckAlarmsCmd(rt *Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:   "check-alarms",
+		Short: "Check for broker-wide alarms",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := rt.AuthenticatedClient(rt.Context())
+			if err != nil {
+				return err
+			}
+			resp, err := client.CheckAlarms(rt.Context())
+			if err != nil {
+				return err
+			}
+			return rt.WriteOutput(resp, func() error {
+				return printHealthResult(rt, resp.Status, resp.Reason)
+			})
+		},
+	}
+}
+
+func newHealthCheckLocalAlarmsCmd(rt *Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:   "check-local-alarms",
+		Short: "Check for local node alarms",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := rt.AuthenticatedClient(rt.Context())
+			if err != nil {
+				return err
+			}
+			resp, err := client.CheckLocalAlarms(rt.Context())
+			if err != nil {
+				return err
+			}
+			return rt.WriteOutput(resp, func() error {
+				return printHealthResult(rt, resp.Status, resp.Reason)
+			})
+		},
+	}
+}
+
+func newHealthCheckPortListenerCmd(rt *Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:   "check-port-listener <port>",
+		Short: "Check if the broker is listening on a given port",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := rt.AuthenticatedClient(rt.Context())
+			if err != nil {
+				return err
+			}
+			resp, err := client.CheckPortListener(rt.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return rt.WriteOutput(resp, func() error {
+				return printHealthResult(rt, resp.Status, resp.Reason)
+			})
+		},
+	}
+}
+
+func newHealthCheckVirtualHostsCmd(rt *Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:   "check-virtual-hosts",
+		Short: "Check that all virtual hosts are running",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := rt.AuthenticatedClient(rt.Context())
+			if err != nil {
+				return err
+			}
+			resp, err := client.CheckVirtualHosts(rt.Context())
+			if err != nil {
+				return err
+			}
+			return rt.WriteOutput(resp, func() error {
+				return printHealthResult(rt, resp.Status, resp.Reason)
+			})
+		},
+	}
+}
+
+func newHealthCheckReadyCmd(rt *Runtime) *cobra.Command {
+	return &cobra.Command{
+		Use:   "check-ready",
+		Short: "Check if the broker is ready to serve clients",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := rt.AuthenticatedClient(rt.Context())
+			if err != nil {
+				return err
+			}
+			resp, err := client.CheckReady(rt.Context())
+			if err != nil {
+				return err
+			}
+			return rt.WriteOutput(resp, func() error {
+				return printHealthResult(rt, resp.Status, resp.Reason)
+			})
+		},
+	}
+}
+
+func printHealthResult(rt *Runtime, status, reason string) error {
+	if reason != "" {
+		return rt.Println(fmt.Sprintf("%s: %s", status, reason))
+	}
+	return rt.Println(status)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,6 +47,7 @@ func NewRootCmd(opts *RootOptions) *cobra.Command {
 	cmd.AddCommand(NewConnectionsCmd(rt))
 	cmd.AddCommand(NewChannelsCmd(rt))
 	cmd.AddCommand(NewConsumersCmd(rt))
+	cmd.AddCommand(NewHealthCmd(rt))
 
 	return cmd
 }

--- a/internal/core/models/responses.go
+++ b/internal/core/models/responses.go
@@ -43,3 +43,8 @@ type ConsumerListResponse struct {
 type MessageListResponse struct {
 	Messages []MessageDTO `json:"messages"`
 }
+
+type HealthCheckResponse struct {
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+}

--- a/pkg/adminapi/client/health.go
+++ b/pkg/adminapi/client/health.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ottermq/ottermq/internal/core/models"
+)
+
+func (c *Client) CheckAlarms(ctx context.Context) (*models.HealthCheckResponse, error) {
+	return c.doHealthCheck(ctx, "/health/checks/alarms")
+}
+
+func (c *Client) CheckLocalAlarms(ctx context.Context) (*models.HealthCheckResponse, error) {
+	return c.doHealthCheck(ctx, "/health/checks/local-alarms")
+}
+
+func (c *Client) CheckPortListener(ctx context.Context, port string) (*models.HealthCheckResponse, error) {
+	return c.doHealthCheck(ctx, fmt.Sprintf("/health/checks/port-listener/%s", port))
+}
+
+func (c *Client) CheckVirtualHosts(ctx context.Context) (*models.HealthCheckResponse, error) {
+	return c.doHealthCheck(ctx, "/health/checks/virtual-hosts")
+}
+
+func (c *Client) CheckReady(ctx context.Context) (*models.HealthCheckResponse, error) {
+	return c.doHealthCheck(ctx, "/health/checks/ready")
+}
+
+// doHealthCheck performs a health check request. It tolerates 503 responses
+// (unhealthy but reachable) and returns the decoded body rather than an error.
+func (c *Client) doHealthCheck(ctx context.Context, path string) (*models.HealthCheckResponse, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var out models.HealthCheckResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil && err != io.EOF {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &out, nil
+}

--- a/web/docs/docs.go
+++ b/web/docs/docs.go
@@ -1515,6 +1515,188 @@ const docTemplate = `{
                 }
             }
         },
+        "/health/checks/alarms": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns ok when no broker-wide alarms are raised. OtterMQ does not yet implement alarms, so this always returns ok.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Check for broker-wide alarms",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.HealthCheckResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/health/checks/local-alarms": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns ok when no local node alarms are raised. OtterMQ does not yet implement alarms, so this always returns ok.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Check for local node alarms",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.HealthCheckResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/health/checks/port-listener/{port}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns ok when the broker is listening on the specified port.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Check if a port is being listened on",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Port number to check",
+                        "name": "port",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.HealthCheckResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/models.HealthCheckResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/health/checks/ready": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns ok when the broker is up and accepting new connections.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Check if the broker is ready to serve clients",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.HealthCheckResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/models.HealthCheckResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/health/checks/virtual-hosts": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns ok when all declared virtual hosts are initialised and operational.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Check that all virtual hosts are running",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.HealthCheckResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/models.HealthCheckResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/login": {
             "post": {
                 "description": "Login",
@@ -2932,6 +3114,17 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/models.ExchangeDTO"
                     }
+                }
+            }
+        },
+        "models.HealthCheckResponse": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
                 }
             }
         },

--- a/web/handlers/api/health.go
+++ b/web/handlers/api/health.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/ottermq/ottermq/internal/core/broker"
+	"github.com/ottermq/ottermq/internal/core/models"
+	"github.com/gofiber/fiber/v2"
+)
+
+// CheckAlarms godoc
+// @Summary Check for broker-wide alarms
+// @Description Returns ok when no broker-wide alarms are raised. OtterMQ does not yet implement alarms, so this always returns ok.
+// @Tags health
+// @Produce json
+// @Success 200 {object} models.HealthCheckResponse
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Router /health/checks/alarms [get]
+// @Security BearerAuth
+func CheckAlarms(c *fiber.Ctx, b *broker.Broker) error {
+	return c.Status(fiber.StatusOK).JSON(models.HealthCheckResponse{Status: "ok"})
+}
+
+// CheckLocalAlarms godoc
+// @Summary Check for local node alarms
+// @Description Returns ok when no local node alarms are raised. OtterMQ does not yet implement alarms, so this always returns ok.
+// @Tags health
+// @Produce json
+// @Success 200 {object} models.HealthCheckResponse
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Router /health/checks/local-alarms [get]
+// @Security BearerAuth
+func CheckLocalAlarms(c *fiber.Ctx, b *broker.Broker) error {
+	return c.Status(fiber.StatusOK).JSON(models.HealthCheckResponse{Status: "ok"})
+}
+
+// CheckPortListener godoc
+// @Summary Check if a port is being listened on
+// @Description Returns ok when the broker is listening on the specified port.
+// @Tags health
+// @Produce json
+// @Param port path string true "Port number to check"
+// @Success 200 {object} models.HealthCheckResponse
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 503 {object} models.HealthCheckResponse
+// @Router /health/checks/port-listener/{port} [get]
+// @Security BearerAuth
+func CheckPortListener(c *fiber.Ctx, b *broker.Broker) error {
+	port := c.Params("port")
+	addr := fmt.Sprintf("localhost:%s", port)
+
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(models.HealthCheckResponse{
+			Status: "failed",
+			Reason: fmt.Sprintf("nothing is listening on port %s", port),
+		})
+	}
+	conn.Close()
+	return c.Status(fiber.StatusOK).JSON(models.HealthCheckResponse{Status: "ok"})
+}
+
+// CheckVirtualHosts godoc
+// @Summary Check that all virtual hosts are running
+// @Description Returns ok when all declared virtual hosts are initialised and operational.
+// @Tags health
+// @Produce json
+// @Success 200 {object} models.HealthCheckResponse
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 503 {object} models.HealthCheckResponse
+// @Router /health/checks/virtual-hosts [get]
+// @Security BearerAuth
+func CheckVirtualHosts(c *fiber.Ctx, b *broker.Broker) error {
+	vhosts, err := b.Management.ListVHosts()
+	if err != nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(models.HealthCheckResponse{
+			Status: "failed",
+			Reason: "could not retrieve virtual hosts",
+		})
+	}
+	for _, v := range vhosts {
+		if b.VHosts[v.Name] == nil {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(models.HealthCheckResponse{
+				Status: "failed",
+				Reason: fmt.Sprintf("virtual host '%s' is not initialised", v.Name),
+			})
+		}
+	}
+	return c.Status(fiber.StatusOK).JSON(models.HealthCheckResponse{Status: "ok"})
+}
+
+// CheckReady godoc
+// @Summary Check if the broker is ready to serve clients
+// @Description Returns ok when the broker is up and accepting new connections.
+// @Tags health
+// @Produce json
+// @Success 200 {object} models.HealthCheckResponse
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 503 {object} models.HealthCheckResponse
+// @Router /health/checks/ready [get]
+// @Security BearerAuth
+func CheckReady(c *fiber.Ctx, b *broker.Broker) error {
+	if b.ShuttingDown.Load() {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(models.HealthCheckResponse{
+			Status: "failed",
+			Reason: "broker is shutting down",
+		})
+	}
+	return c.Status(fiber.StatusOK).JSON(models.HealthCheckResponse{Status: "ok"})
+}

--- a/web/server.go
+++ b/web/server.go
@@ -185,6 +185,24 @@ func (ws *WebServer) AddApi(app *fiber.App) {
 		return api.GetChannel(c, ws.Broker)
 	})
 
+	// Health check routes
+
+	apiGrp.Get("/health/checks/alarms", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {
+		return api.CheckAlarms(c, ws.Broker)
+	})
+	apiGrp.Get("/health/checks/local-alarms", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {
+		return api.CheckLocalAlarms(c, ws.Broker)
+	})
+	apiGrp.Get("/health/checks/port-listener/:port", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {
+		return api.CheckPortListener(c, ws.Broker)
+	})
+	apiGrp.Get("/health/checks/virtual-hosts", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {
+		return api.CheckVirtualHosts(c, ws.Broker)
+	})
+	apiGrp.Get("/health/checks/ready", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {
+		return api.CheckReady(c, ws.Broker)
+	})
+
 	// Connection routes
 
 	apiGrp.Get("/connections", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {


### PR DESCRIPTION
## Summary

- Adds 5 health check endpoints under `GET /api/health/checks/*`: `alarms`, `local-alarms`, `port-listener/{port}`, `virtual-hosts`, and `ready`
- Each returns `{"status":"ok"}` on healthy or `{"status":"failed","reason":"..."}` + HTTP 503 on unhealthy
- Wires corresponding client methods in `pkg/adminapi/client/health.go`
- Adds `ottermqadmin health` CLI command group with subcommands mirroring the five endpoints

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/cli/... ./pkg/adminapi/... ./web/...` passes
- [ ] `ottermqadmin health check-alarms` returns `ok`
- [ ] `ottermqadmin health check-port-listener 5672` returns `ok` when broker is running
- [ ] `ottermqadmin health check-ready` returns `ok` on a live broker