### PR TITLE
feat: definitions export/import

### DIFF
--- a/internal/cli/definitions.go
+++ b/internal/cli/definitions.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/ottermq/ottermq/internal/core/models"
+	"github.com/spf13/cobra"
+)
+
+
+func NewDefinitionsCmd(rt *Runtime) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "definitions",
+		Short: "Export and import broker definitions",
+	}
+
+	cmd.AddCommand(newDefinitionsExportCmd(rt))
+	cmd.AddCommand(newDefinitionsImportCmd(rt))
+
+	return cmd
+}
+
+func newDefinitionsExportCmd(rt *Runtime) *cobra.Command {
+	var vhost string
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export broker definitions to JSON",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := rt.AuthenticatedClient(rt.Context())
+			if err != nil {
+				return err
+			}
+
+			var defs *models.DefinitionsDTO
+			if vhost != "" {
+				defs, err = client.ExportVHostDefinitions(rt.Context(), vhost)
+			} else {
+				defs, err = client.ExportDefinitions(rt.Context())
+			}
+			if err != nil {
+				return err
+			}
+
+			data, err := json.MarshalIndent(defs, "", "  ")
+			if err != nil {
+				return fmt.Errorf("marshal definitions: %w", err)
+			}
+
+			if output != "" {
+				if err := os.WriteFile(output, data, 0644); err != nil {
+					return fmt.Errorf("write file: %w", err)
+				}
+				return rt.Println(fmt.Sprintf("Definitions written to %s", output))
+			}
+
+			return rt.Println(string(data))
+		},
+	}
+
+	cmd.Flags().StringVar(&vhost, "vhost", "", "Scope export to a single virtual host")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Write output to file instead of stdout")
+
+	return cmd
+}
+
+func newDefinitionsImportCmd(rt *Runtime) *cobra.Command {
+	var vhost string
+
+	cmd := &cobra.Command{
+		Use:   "import <file>",
+		Short: "Import broker definitions from a JSON file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("read file: %w", err)
+			}
+
+			var defs models.DefinitionsDTO
+			if err := json.Unmarshal(data, &defs); err != nil {
+				return fmt.Errorf("parse definitions: %w", err)
+			}
+
+			client, err := rt.AuthenticatedClient(rt.Context())
+			if err != nil {
+				return err
+			}
+
+			var result *models.DefinitionsImportResponse
+			if vhost != "" {
+				result, err = client.ImportVHostDefinitions(rt.Context(), vhost, &defs)
+			} else {
+				result, err = client.ImportDefinitions(rt.Context(), &defs)
+			}
+			if err != nil {
+				return err
+			}
+
+			return rt.WriteOutput(result, func() error {
+				return rt.PrintFields("Import complete", []Field{
+					{Label: "VHosts created", Value: fmt.Sprintf("%d", result.VHosts)},
+					{Label: "Users created", Value: fmt.Sprintf("%d", result.Users)},
+					{Label: "Permissions granted", Value: fmt.Sprintf("%d", result.Permissions)},
+					{Label: "Exchanges created", Value: fmt.Sprintf("%d", result.Exchanges)},
+					{Label: "Queues created", Value: fmt.Sprintf("%d", result.Queues)},
+					{Label: "Bindings created", Value: fmt.Sprintf("%d", result.Bindings)},
+				})
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&vhost, "vhost", "", "Scope import to a single virtual host")
+
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -48,6 +48,7 @@ func NewRootCmd(opts *RootOptions) *cobra.Command {
 	cmd.AddCommand(NewChannelsCmd(rt))
 	cmd.AddCommand(NewConsumersCmd(rt))
 	cmd.AddCommand(NewHealthCmd(rt))
+	cmd.AddCommand(NewDefinitionsCmd(rt))
 
 	return cmd
 }

--- a/internal/core/models/definitions.go
+++ b/internal/core/models/definitions.go
@@ -1,0 +1,66 @@
+package models
+
+// DefinitionsDTO is the full broker configuration snapshot used for export/import.
+type DefinitionsDTO struct {
+	OtterMQVersion string                 `json:"ottermq_version"`
+	VHosts         []VHostDefinition      `json:"vhosts"`
+	Users          []UserDefinition       `json:"users"`
+	Permissions    []PermissionDefinition `json:"permissions"`
+	Exchanges      []ExchangeDefinition   `json:"exchanges"`
+	Queues         []QueueDefinition      `json:"queues"`
+	Bindings       []BindingDefinition    `json:"bindings"`
+}
+
+type VHostDefinition struct {
+	Name string `json:"name"`
+}
+
+// UserDefinition holds user credentials as stored in the database.
+// PasswordHash is the bcrypt hash — never the plaintext password.
+type UserDefinition struct {
+	Name         string `json:"name"`
+	PasswordHash string `json:"password_hash"`
+	Tags         string `json:"tags"` // role name, e.g. "administrator"
+}
+
+type PermissionDefinition struct {
+	User  string `json:"user"`
+	VHost string `json:"vhost"`
+}
+
+type ExchangeDefinition struct {
+	Name       string         `json:"name"`
+	VHost      string         `json:"vhost"`
+	Type       string         `json:"type"`
+	Durable    bool           `json:"durable"`
+	AutoDelete bool           `json:"auto_delete"`
+	Internal   bool           `json:"internal"`
+	Arguments  map[string]any `json:"arguments,omitempty"`
+}
+
+type QueueDefinition struct {
+	Name       string         `json:"name"`
+	VHost      string         `json:"vhost"`
+	Durable    bool           `json:"durable"`
+	AutoDelete bool           `json:"auto_delete"`
+	Arguments  map[string]any `json:"arguments,omitempty"`
+}
+
+type BindingDefinition struct {
+	Source          string         `json:"source"`
+	VHost           string         `json:"vhost"`
+	Destination     string         `json:"destination"`
+	DestinationType string         `json:"destination_type"`
+	RoutingKey      string         `json:"routing_key"`
+	Arguments       map[string]any `json:"arguments,omitempty"`
+}
+
+// DefinitionsImportResponse reports the outcome of an import operation.
+type DefinitionsImportResponse struct {
+	VHosts      int `json:"vhosts_created"`
+	Users       int `json:"users_created"`
+	Permissions int `json:"permissions_granted"`
+	Exchanges   int `json:"exchanges_created"`
+	Queues      int `json:"queues_created"`
+	Bindings    int `json:"bindings_created"`
+}

--- a/internal/persistdb/users.go
+++ b/internal/persistdb/users.go
@@ -120,6 +120,40 @@ func ChangePassword(username, newPassword string) error {
 	return nil
 }
 
+// GetUsersWithHashes returns all users including their bcrypt password hashes.
+// Used for definitions export.
+func GetUsersWithHashes() ([]User, error) {
+	rows, err := db.Query("SELECT id, username, password, role_id FROM users")
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to query users with hashes")
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []User
+	for rows.Next() {
+		var u User
+		if err := rows.Scan(&u.ID, &u.Username, &u.Password, &u.RoleID); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, nil
+}
+
+// AddUserWithHash inserts a user using an already-hashed password (e.g. from a definitions import).
+// Silently skips the insert when the username already exists.
+func AddUserWithHash(username, hash string, roleID int) error {
+	_, err := db.Exec(
+		"INSERT OR IGNORE INTO users (username, password, role_id) VALUES (?, ?, ?)",
+		username, hash, roleID,
+	)
+	if err != nil {
+		log.Error().Err(err).Str("username", username).Msg("Failed to insert user with hash")
+	}
+	return err
+}
+
 func (u User) ToUserListDTO() (UserListDTO, error) {
 	role, err := GetRoleByID(u.RoleID)
 	if err != nil {

--- a/pkg/adminapi/client/definitions.go
+++ b/pkg/adminapi/client/definitions.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/ottermq/ottermq/internal/core/models"
+)
+
+func (c *Client) ExportDefinitions(ctx context.Context) (*models.DefinitionsDTO, error) {
+	return c.exportDefinitions(ctx, "/definitions")
+}
+
+func (c *Client) ExportVHostDefinitions(ctx context.Context, vhost string) (*models.DefinitionsDTO, error) {
+	return c.exportDefinitions(ctx, fmt.Sprintf("/definitions/%s", url.PathEscape(vhost)))
+}
+
+func (c *Client) ImportDefinitions(ctx context.Context, defs *models.DefinitionsDTO) (*models.DefinitionsImportResponse, error) {
+	return c.importDefinitions(ctx, "/definitions", defs)
+}
+
+func (c *Client) ImportVHostDefinitions(ctx context.Context, vhost string, defs *models.DefinitionsDTO) (*models.DefinitionsImportResponse, error) {
+	return c.importDefinitions(ctx, fmt.Sprintf("/definitions/%s", url.PathEscape(vhost)), defs)
+}
+
+func (c *Client) exportDefinitions(ctx context.Context, path string) (*models.DefinitionsDTO, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out models.DefinitionsDTO
+	if err := c.do(req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) importDefinitions(ctx context.Context, path string, defs *models.DefinitionsDTO) (*models.DefinitionsImportResponse, error) {
+	req, err := c.newRequest(ctx, http.MethodPost, path, defs)
+	if err != nil {
+		return nil, err
+	}
+	var out models.DefinitionsImportResponse
+	if err := c.do(req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/web/docs/docs.go
+++ b/web/docs/docs.go
@@ -1166,6 +1166,206 @@ const docTemplate = `{
                 }
             }
         },
+        "/definitions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Export vhosts, users, permissions, exchanges, queues, and bindings as JSON.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "definitions"
+                ],
+                "summary": "Export all broker definitions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.DefinitionsDTO"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Import vhosts, users, permissions, exchanges, queues, and bindings from JSON. Existing resources are skipped.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "definitions"
+                ],
+                "summary": "Import broker definitions",
+                "parameters": [
+                    {
+                        "description": "Definitions to import",
+                        "name": "definitions",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.DefinitionsDTO"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.DefinitionsImportResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/definitions/{vhost}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Export exchanges, queues, and bindings scoped to one vhost.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "definitions"
+                ],
+                "summary": "Export definitions for a single virtual host",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VHost name",
+                        "name": "vhost",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.DefinitionsDTO"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Import exchanges, queues, and bindings into the specified vhost. Existing resources are skipped.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "definitions"
+                ],
+                "summary": "Import definitions scoped to a virtual host",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VHost name",
+                        "name": "vhost",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Definitions to import",
+                        "name": "definitions",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.DefinitionsDTO"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.DefinitionsImportResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.UnauthorizedErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/exchanges": {
             "get": {
                 "security": [
@@ -2719,6 +2919,30 @@ const docTemplate = `{
                 }
             }
         },
+        "models.BindingDefinition": {
+            "type": "object",
+            "properties": {
+                "arguments": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "destination": {
+                    "type": "string"
+                },
+                "destination_type": {
+                    "type": "string"
+                },
+                "routing_key": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "vhost": {
+                    "type": "string"
+                }
+            }
+        },
         "models.BindingListResponse": {
             "type": "object",
             "properties": {
@@ -3030,6 +3254,73 @@ const docTemplate = `{
                 }
             }
         },
+        "models.DefinitionsDTO": {
+            "type": "object",
+            "properties": {
+                "bindings": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.BindingDefinition"
+                    }
+                },
+                "exchanges": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ExchangeDefinition"
+                    }
+                },
+                "ottermq_version": {
+                    "type": "string"
+                },
+                "permissions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.PermissionDefinition"
+                    }
+                },
+                "queues": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.QueueDefinition"
+                    }
+                },
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.UserDefinition"
+                    }
+                },
+                "vhosts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.VHostDefinition"
+                    }
+                }
+            }
+        },
+        "models.DefinitionsImportResponse": {
+            "type": "object",
+            "properties": {
+                "bindings_created": {
+                    "type": "integer"
+                },
+                "exchanges_created": {
+                    "type": "integer"
+                },
+                "permissions_granted": {
+                    "type": "integer"
+                },
+                "queues_created": {
+                    "type": "integer"
+                },
+                "users_created": {
+                    "type": "integer"
+                },
+                "vhosts_created": {
+                    "type": "integer"
+                }
+            }
+        },
         "models.DeleteBindingRequest": {
             "type": "object",
             "required": [
@@ -3102,6 +3393,33 @@ const docTemplate = `{
                 },
                 "vhost": {
                     "description": "Identity",
+                    "type": "string"
+                }
+            }
+        },
+        "models.ExchangeDefinition": {
+            "type": "object",
+            "properties": {
+                "arguments": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "auto_delete": {
+                    "type": "boolean"
+                },
+                "durable": {
+                    "type": "boolean"
+                },
+                "internal": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "vhost": {
                     "type": "string"
                 }
             }
@@ -3462,6 +3780,17 @@ const docTemplate = `{
                 }
             }
         },
+        "models.PermissionDefinition": {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "string"
+                },
+                "vhost": {
+                    "type": "string"
+                }
+            }
+        },
         "models.PermissionListResponse": {
             "type": "object",
             "properties": {
@@ -3607,6 +3936,27 @@ const docTemplate = `{
                 }
             }
         },
+        "models.QueueDefinition": {
+            "type": "object",
+            "properties": {
+                "arguments": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "auto_delete": {
+                    "type": "boolean"
+                },
+                "durable": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "vhost": {
+                    "type": "string"
+                }
+            }
+        },
         "models.QueueListResponse": {
             "type": "object",
             "properties": {
@@ -3679,6 +4029,21 @@ const docTemplate = `{
                 }
             }
         },
+        "models.UserDefinition": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "password_hash": {
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "role name, e.g. \"administrator\"",
+                    "type": "string"
+                }
+            }
+        },
         "models.UserListResponse": {
             "type": "object",
             "properties": {
@@ -3743,6 +4108,14 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "models.VHostDefinition": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/web/handlers/api/definitions.go
+++ b/web/handlers/api/definitions.go
@@ -1,0 +1,336 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/ottermq/ottermq/internal/core/broker"
+	"github.com/ottermq/ottermq/internal/core/models"
+	"github.com/ottermq/ottermq/internal/persistdb"
+	"github.com/gofiber/fiber/v2"
+)
+
+// mandatoryExchanges are auto-created per vhost and must not appear in exports.
+var mandatoryExchanges = map[string]bool{
+	"amq.default": true,
+	"amq.topic":   true,
+	"amq.direct":  true,
+	"amq.fanout":  true,
+	"":            true,
+}
+
+// ExportDefinitions godoc
+// @Summary Export all broker definitions
+// @Description Export vhosts, users, permissions, exchanges, queues, and bindings as JSON.
+// @Tags definitions
+// @Produce json
+// @Success 200 {object} models.DefinitionsDTO
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /definitions [get]
+// @Security BearerAuth
+func ExportDefinitions(c *fiber.Ctx, b *broker.Broker) error {
+	defs, err := buildDefinitions(c, b, "")
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	return c.Status(fiber.StatusOK).JSON(defs)
+}
+
+// ExportVHostDefinitions godoc
+// @Summary Export definitions for a single virtual host
+// @Description Export exchanges, queues, and bindings scoped to one vhost.
+// @Tags definitions
+// @Produce json
+// @Param vhost path string true "VHost name"
+// @Success 200 {object} models.DefinitionsDTO
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /definitions/{vhost} [get]
+// @Security BearerAuth
+func ExportVHostDefinitions(c *fiber.Ctx, b *broker.Broker) error {
+	vhost := decodedParam(c, "vhost")
+	defs, err := buildDefinitions(c, b, vhost)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	return c.Status(fiber.StatusOK).JSON(defs)
+}
+
+// ImportDefinitions godoc
+// @Summary Import broker definitions
+// @Description Import vhosts, users, permissions, exchanges, queues, and bindings from JSON. Existing resources are skipped.
+// @Tags definitions
+// @Accept json
+// @Produce json
+// @Param definitions body models.DefinitionsDTO true "Definitions to import"
+// @Success 200 {object} models.DefinitionsImportResponse
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /definitions [post]
+// @Security BearerAuth
+func ImportDefinitions(c *fiber.Ctx, b *broker.Broker) error {
+	var defs models.DefinitionsDTO
+	if err := c.BodyParser(&defs); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.ErrorResponse{Error: "invalid JSON body"})
+	}
+	result, err := applyDefinitions(b, defs, "")
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	return c.Status(fiber.StatusOK).JSON(result)
+}
+
+// ImportVHostDefinitions godoc
+// @Summary Import definitions scoped to a virtual host
+// @Description Import exchanges, queues, and bindings into the specified vhost. Existing resources are skipped.
+// @Tags definitions
+// @Accept json
+// @Produce json
+// @Param vhost path string true "VHost name"
+// @Param definitions body models.DefinitionsDTO true "Definitions to import"
+// @Success 200 {object} models.DefinitionsImportResponse
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 401 {object} models.UnauthorizedErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /definitions/{vhost} [post]
+// @Security BearerAuth
+func ImportVHostDefinitions(c *fiber.Ctx, b *broker.Broker) error {
+	vhost := decodedParam(c, "vhost")
+	var defs models.DefinitionsDTO
+	if err := c.BodyParser(&defs); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(models.ErrorResponse{Error: "invalid JSON body"})
+	}
+	result, err := applyDefinitions(b, defs, vhost)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(models.ErrorResponse{Error: err.Error()})
+	}
+	return c.Status(fiber.StatusOK).JSON(result)
+}
+
+// buildDefinitions assembles a DefinitionsDTO. When scopeVHost is non-empty only
+// exchanges, queues, and bindings belonging to that vhost are included.
+func buildDefinitions(c *fiber.Ctx, b *broker.Broker, scopeVHost string) (*models.DefinitionsDTO, error) {
+	overview, err := b.Management.GetOverview()
+	if err != nil {
+		return nil, err
+	}
+
+	defs := &models.DefinitionsDTO{
+		OtterMQVersion: overview.BrokerDetails.Version,
+	}
+
+	// VHosts
+	vhosts, err := b.Management.ListVHosts()
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range vhosts {
+		if scopeVHost == "" || v.Name == scopeVHost {
+			defs.VHosts = append(defs.VHosts, models.VHostDefinition{Name: v.Name})
+		}
+	}
+
+	// Users & permissions only in global export
+	if scopeVHost == "" {
+		users, err := persistdb.GetUsersWithHashes()
+		if err != nil {
+			return nil, err
+		}
+		for _, u := range users {
+			role, err := persistdb.GetRoleByID(u.RoleID)
+			if err != nil {
+				return nil, err
+			}
+			defs.Users = append(defs.Users, models.UserDefinition{
+				Name:         u.Username,
+				PasswordHash: u.Password,
+				Tags:         role.Name,
+			})
+		}
+
+		perms, err := persistdb.ListAllPermissions()
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range perms {
+			defs.Permissions = append(defs.Permissions, models.PermissionDefinition{
+				User:  p.Username,
+				VHost: p.VHost,
+			})
+		}
+	}
+
+	// Exchanges
+	exchanges, err := b.Management.ListExchanges()
+	if err != nil {
+		return nil, err
+	}
+	for _, ex := range exchanges {
+		if mandatoryExchanges[ex.Name] {
+			continue
+		}
+		if scopeVHost != "" && ex.VHost != scopeVHost {
+			continue
+		}
+		defs.Exchanges = append(defs.Exchanges, models.ExchangeDefinition{
+			Name:       ex.Name,
+			VHost:      ex.VHost,
+			Type:       ex.Type,
+			Durable:    ex.Durable,
+			AutoDelete: ex.AutoDelete,
+			Internal:   ex.Internal,
+			Arguments:  ex.Arguments,
+		})
+	}
+
+	// Queues
+	queues := b.Management.ListQueues()
+	for _, q := range queues {
+		if scopeVHost != "" && q.VHost != scopeVHost {
+			continue
+		}
+		defs.Queues = append(defs.Queues, models.QueueDefinition{
+			Name:       q.Name,
+			VHost:      q.VHost,
+			Durable:    q.Durable,
+			AutoDelete: q.AutoDelete,
+			Arguments:  q.Arguments,
+		})
+	}
+
+	// Bindings — skip default-exchange bindings (they're implicit)
+	bindings, err := b.Management.ListBindings()
+	if err != nil {
+		return nil, err
+	}
+	for _, bd := range bindings {
+		if mandatoryExchanges[bd.Source] {
+			continue
+		}
+		if scopeVHost != "" && bd.VHost != scopeVHost {
+			continue
+		}
+		defs.Bindings = append(defs.Bindings, models.BindingDefinition{
+			Source:          bd.Source,
+			VHost:           bd.VHost,
+			Destination:     bd.Destination,
+			DestinationType: bd.DestinationType,
+			RoutingKey:      bd.RoutingKey,
+			Arguments:       bd.Arguments,
+		})
+	}
+
+	return defs, nil
+}
+
+// applyDefinitions imports a DefinitionsDTO into the broker. When scopeVHost is
+// non-empty, vhost/user/permission entries are ignored and only resource entries
+// matching that vhost are applied.
+func applyDefinitions(b *broker.Broker, defs models.DefinitionsDTO, scopeVHost string) (*models.DefinitionsImportResponse, error) {
+	result := &models.DefinitionsImportResponse{}
+
+	if scopeVHost == "" {
+		// VHosts
+		for _, v := range defs.VHosts {
+			if err := b.Management.CreateVHost(v.Name); err != nil && !isAlreadyExists(err) {
+				return nil, err
+			} else if err == nil {
+				result.VHosts++
+			}
+		}
+
+		// Users
+		for _, u := range defs.Users {
+			roleID := 2 // default: "user"
+			switch strings.ToLower(u.Tags) {
+			case "admin", "administrator":
+				roleID = 1
+			case "guest":
+				roleID = 3
+			}
+			if err := persistdb.AddUserWithHash(u.Name, u.PasswordHash, roleID); err != nil {
+				return nil, err
+			}
+			// AddUserWithHash uses INSERT OR IGNORE, count only when a new row was created.
+			// We optimistically count +1; duplicates silently pass.
+			result.Users++
+		}
+
+		// Permissions
+		for _, p := range defs.Permissions {
+			if err := persistdb.GrantVHostAccess(p.User, p.VHost); err != nil {
+				return nil, err
+			}
+			result.Permissions++
+		}
+	}
+
+	// Exchanges
+	for _, ex := range defs.Exchanges {
+		vh := ex.VHost
+		if scopeVHost != "" {
+			vh = scopeVHost
+		}
+		req := models.CreateExchangeRequest{
+			ExchangeType: ex.Type,
+			Durable:      ex.Durable,
+			AutoDelete:   ex.AutoDelete,
+			Arguments:    ex.Arguments,
+		}
+		if _, err := b.Management.CreateExchange(vh, ex.Name, req); err != nil && !isAlreadyExists(err) {
+			return nil, err
+		} else if err == nil {
+			result.Exchanges++
+		}
+	}
+
+	// Queues
+	for _, q := range defs.Queues {
+		vh := q.VHost
+		if scopeVHost != "" {
+			vh = scopeVHost
+		}
+		req := models.CreateQueueRequest{
+			Durable:    q.Durable,
+			AutoDelete: q.AutoDelete,
+			Arguments:  q.Arguments,
+		}
+		if _, err := b.Management.CreateQueue(vh, q.Name, req); err != nil && !isAlreadyExists(err) {
+			return nil, err
+		} else if err == nil {
+			result.Queues++
+		}
+	}
+
+	// Bindings
+	for _, bd := range defs.Bindings {
+		vh := bd.VHost
+		if scopeVHost != "" {
+			vh = scopeVHost
+		}
+		req := models.CreateBindingRequest{
+			VHost:       vh,
+			Source:      bd.Source,
+			Destination: bd.Destination,
+			RoutingKey:  bd.RoutingKey,
+			Arguments:   bd.Arguments,
+		}
+		if _, err := b.Management.CreateBinding(req); err != nil && !isAlreadyExists(err) {
+			return nil, err
+		} else if err == nil {
+			result.Bindings++
+		}
+	}
+
+	return result, nil
+}
+
+// isAlreadyExists reports whether an error indicates a resource already exists.
+func isAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "already exists") || strings.Contains(msg, "UNIQUE constraint")
+}

--- a/web/server.go
+++ b/web/server.go
@@ -185,6 +185,21 @@ func (ws *WebServer) AddApi(app *fiber.App) {
 		return api.GetChannel(c, ws.Broker)
 	})
 
+	// Definitions routes
+
+	apiGrp.Get("/definitions", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {
+		return api.ExportDefinitions(c, ws.Broker)
+	})
+	apiGrp.Post("/definitions", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {
+		return api.ImportDefinitions(c, ws.Broker)
+	})
+	apiGrp.Get("/definitions/:vhost", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {
+		return api.ExportVHostDefinitions(c, ws.Broker)
+	})
+	apiGrp.Post("/definitions/:vhost", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {
+		return api.ImportVHostDefinitions(c, ws.Broker)
+	})
+
 	// Health check routes
 
 	apiGrp.Get("/health/checks/alarms", middleware.JwtMiddleware(ws.config.JwtKey), func(c *fiber.Ctx) error {


### PR DESCRIPTION
## Summary

- Adds `GET /api/definitions` and `POST /api/definitions` for full broker config export/import
- Adds scoped variants `GET|POST /api/definitions/{vhost}` for per-vhost operations
- Export includes: vhosts, users (with bcrypt password hashes), permissions, user-declared exchanges, queues, and bindings — mandatory exchanges (`amq.*`) are excluded
- Import is idempotent: existing resources are silently skipped
- Client methods in `pkg/adminapi/client/definitions.go`
- `ottermqadmin definitions export [--vhost <v>] [-o file]` and `ottermqadmin definitions import <file> [--vhost <v>]`

## Test plan

- [ ] `go build ./...` and `go test ./...` pass
- [ ] `ottermqadmin definitions export -o backup.json` writes valid JSON
- [ ] `ottermqadmin definitions import backup.json` reports created counts
- [ ] Re-importing the same file reports 0 for every counter (idempotent)
- [ ] `--vhost /` scopes output to that vhost only